### PR TITLE
chore/migrate utils dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ __pycache__/
 # IDE
 .idea/
 .cursor/
+
+# Proprietary code (must not be tracked in FOSS repo)
+blueflow/

--- a/bf_opencore/models/asset.py
+++ b/bf_opencore/models/asset.py
@@ -24,7 +24,7 @@ import packaging.version
 import netaddr
 
 from django.apps import apps
-from utils import NullUnlessChanged
+from bf_opencore.utils import NullUnlessChanged
 
 from .asset_manager import AssetManager, AssetQuerySet, _unflatten_json_field
 from .asset_custom_field import AssetCustomFieldName, AssetCustomField

--- a/bf_opencore/models/asset_manager.py
+++ b/bf_opencore/models/asset_manager.py
@@ -15,7 +15,7 @@ from django.db.models.functions import Coalesce
 from django.core.exceptions import FieldError, ValidationError
 
 from django.apps import apps
-from utils import Created
+from bf_opencore.utils import Created
 
 from .network import Network
 

--- a/bf_opencore/models/connector.py
+++ b/bf_opencore/models/connector.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 from django.db import models
 from django_celery_beat.models import PeriodicTask
 from django.apps import apps
-from blueflow.exceptions import ConnectorConfigError
+from bf_opencore.exceptions import ConnectorConfigError
 
 logger = logging.getLogger(__name__)
 

--- a/bf_opencore/models/connector_task.py
+++ b/bf_opencore/models/connector_task.py
@@ -14,7 +14,7 @@ import celery
 from django.db import models
 from django.db.models import F
 from django.utils import timezone
-from blueflow.exceptions import ConnectorTaskError
+from bf_opencore.exceptions import ConnectorTaskError
 from .connector import Connector
 
 logger = logging.getLogger(__name__)

--- a/bf_opencore/models/network.py
+++ b/bf_opencore/models/network.py
@@ -12,7 +12,7 @@ from django.core import exceptions as d_ex
 from netfields import CidrAddressField, NetManager
 
 from django.apps import apps
-from utils import ipset_from_network
+from bf_opencore.utils import ipset_from_network
 
 logger = logging.getLogger(__name__)
 

--- a/bf_opencore/models/network_endpoint.py
+++ b/bf_opencore/models/network_endpoint.py
@@ -8,7 +8,7 @@ from django.db.models.signals import post_save
 from netfields import MACAddressField, InetAddressField
 
 from django.apps import apps
-from utils import DisableSignals
+from bf_opencore.utils import DisableSignals
 
 
 class NetworkEndpointManager(models.Manager):

--- a/bf_opencore/models/pulse.py
+++ b/bf_opencore/models/pulse.py
@@ -9,8 +9,7 @@ from django.contrib.postgres.fields import ArrayField
 from django.utils import timezone
 from simple_history.models import HistoricalRecords
 from django.apps import apps
-from utils import quarter_start, prev_quarter_start
-from utils import NullUnlessChanged
+from bf_opencore.utils import quarter_start, prev_quarter_start, NullUnlessChanged
 
 logger = logging.getLogger(__name__)
 

--- a/bf_opencore/utils/__init__.py
+++ b/bf_opencore/utils/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2017-2019 Virta Laboratories, Inc.  All rights reserved.
+
+"""Utils that are useful for many apps."""
+
+import collections
+from enum import Enum, auto
+
+from .ipset import ipset_from_network
+from .disable_signals import DisableSignals
+from .func import NullUnlessChanged
+from .quarters import quarter_start, prev_quarter_start
+
+
+def iterable(arg):
+    """Check if something is really an iterable but not a string."""
+    return (isinstance(arg, collections.abc.Iterable) and
+            not isinstance(arg, str))
+
+
+class Created(Enum):
+    """Extended Django's "created" flag to include up-to-date."""
+
+    UPDATED = auto()
+    CREATED = auto()
+    UPTODATE = auto()
+
+    def __bool__(self):
+        """Mimic Django behavior in if-statements.
+
+        Return True if created, otherwise False.
+        """
+        # We need to access private member to get this job done
+        # pylint: disable=protected-access,no-member
+        return self._value_ == self.CREATED._value_

--- a/bf_opencore/utils/disable_signals.py
+++ b/bf_opencore/utils/disable_signals.py
@@ -1,0 +1,50 @@
+"""Disable all signals.
+
+Lifted from https://gist.github.com/shibocuhk/fd0e3f5e2360c64bc9ce2efb254744f7
+"""
+
+from collections import defaultdict
+from django.db.models.signals import pre_init, post_init, pre_save, \
+    post_save, pre_delete, post_delete, pre_migrate, post_migrate
+
+
+class DisableSignals():
+    """Context manager that will disable all (or specified) signals.
+
+    Example usage:
+    with DisableSignals():
+        user.save()  # will not call any signals
+
+    with DisableSignals([post_save]):
+        user.save()  # will not call any receivers for post_save signal
+
+    NOTE: argument is given as a list of signals, even though there may
+    be only one.
+    """
+
+    def __init__(self, disabled_signals=None):  # noqa=D107
+        self.stashed_signals = defaultdict(list)
+        self.disabled_signals = disabled_signals or [
+            pre_init, post_init,
+            pre_save, post_save,
+            pre_delete, post_delete,
+            pre_migrate, post_migrate,
+        ]
+
+    def __enter__(self):  # noqa=D105
+        for signal in self.disabled_signals:
+            self.disconnect(signal)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):  # noqa=D105
+        for signal in list(self.stashed_signals.keys()):
+            self.reconnect(signal)
+
+    def disconnect(self, signal):
+        """Put aside receivers for the given signal."""
+        self.stashed_signals[signal] = signal.receivers
+        signal.receivers = []
+
+    def reconnect(self, signal):
+        """Put receivers back in."""
+        signal.receivers = self.stashed_signals.get(signal, [])
+        del self.stashed_signals[signal]

--- a/bf_opencore/utils/func.py
+++ b/bf_opencore/utils/func.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2017-2019 Virta Laboratories, Inc.  All rights reserved.
+
+"""Custom Django functions."""
+
+
+from django.db.models import Func
+
+
+class NullUnlessChanged(Func):
+    """Custom Django function.
+
+    Based on the Postgres Window function LAG and NULLIF.
+
+    Corresponding Field ('expression') is NULL if unchanged from previous.
+    It works by comparing (with NULLIF) the field value against the
+    previous value (with LAG, using the default OFFSET of 1.)
+
+    Used in order to detect when a (any) field changed.
+    """
+
+    # Apparently I should have overridden __and__, __or__, __rand__, __ror__.
+    # pylint: disable=abstract-method
+
+    function = None  # unused, but should be there in most customs.
+    template = """
+      NULLIF(%(expressions)s,
+             LAG(%(expressions)s) OVER (ORDER BY history_date))
+    """

--- a/bf_opencore/utils/ipset.py
+++ b/bf_opencore/utils/ipset.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2016-2017 Virta Laboratories, Inc.  All rights reserved.
+
+"""Translate ip addresses."""
+
+import logging
+import netaddr
+
+logger = logging.getLogger(__name__)
+
+
+def ipset_from_network(network):
+    """Return a netaddr.IPSet from a CIDR, glob, or nmap range string.
+
+    >>> ipset_from_network('10.0.1.14')
+    IPSet(['10.0.1.14/32'])
+    >>> ipset_from_network('10.0.1.14/24')
+    IPSet(['10.0.1.0/24'])
+    >>> ipset_from_network('10.0.1.14/29')
+    IPSet(['10.0.1.8/29'])
+    >>> ipset_from_network('10.0.1.*')
+    IPSet(['10.0.1.0/24'])
+    >>> ipset_from_network('10.0.1.8-23')
+    IPSet([])
+    >>> ipset_from_network('10.0.2-3.0-255')
+    IPSet([])
+    >>> ipset_from_network('10.0.2-3.*')
+    IPSet([])
+    >>> ipset_from_network('10.0.1.14, 10.0.1.15')
+    IPSet(['10.0.1.14/31'])
+    >>> ipset_from_network('10.0.1.14,10.0.1.15')
+    IPSet(['10.0.1.14/31'])
+    >>> ipset_from_network('10.0.1.14 10.0.1.15')
+    IPSet(['10.0.1.14/31'])
+    >>> ipset_from_network('foobar')
+    IPSet([])
+    >>> ipset_from_network('10.0.1.14 foobar')
+    IPSet(['10.0.1.14/32'])
+    """
+    nwks = network.replace(',', ' ').split()  # Split on comma or whitespace
+    # "A foolish consistency ..." - it makes most sense to compare on len here
+    # pylint: disable=len-as-condition
+    if len(nwks) > 1:
+        # Comma or whitespace-separated list of network, interpret each
+        # of them and join'em all together
+        ipset = netaddr.IPSet()
+        for nwk in nwks:
+            ipset.update(_ipset_from_simple_network(nwk))
+        return ipset
+    elif len(nwks) == 0:
+        # No networks in string; return empty IPSet
+        return netaddr.IPSet()
+    elif len(nwks) == 1:
+        # One network in string, fall through to the rest of the function
+        return _ipset_from_simple_network(nwks[0])
+
+    # Should never get here, but pylint doesn't know this
+    return None
+
+
+def _ipset_from_simple_network(network):
+    """Convert a CIDR or glob (not dashed range) to an IPSet.
+
+    >>> _ipset_from_simple_network('10.0.1.14')
+    IPSet(['10.0.1.14/32'])
+    >>> _ipset_from_simple_network('10.0.1.14/24')
+    IPSet(['10.0.1.0/24'])
+    >>> _ipset_from_simple_network('10.0.1.14, 10.0.1.15')
+    IPSet([])
+    """
+    if '-' in network:
+        logger.error('Nmap ranges like "%s" are not supported.', network)
+        return netaddr.IPSet()
+
+    if netaddr.valid_glob(network):
+        # This will handle '10.0.1.*' style globs
+        return netaddr.IPSet(netaddr.IPGlob(network))
+
+    if netaddr.valid_nmap_range(network):
+        # This will handle nmap ranges and CIDRs (and individual hosts)
+        # return netaddr.IPSet(netaddr.iter_nmap_range(network))
+        return netaddr.IPSet(netaddr.IPNetwork(network).cidr)
+
+    logger.error("Not a valid network: '%s'", network)
+    return netaddr.IPSet()

--- a/bf_opencore/utils/quarters.py
+++ b/bf_opencore/utils/quarters.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2019 Virta Laboratories, Inc.  All rights reserved.
+
+"""Calculate beginning and end dates of quarters."""
+
+import datetime
+
+
+def quarter(dt):
+    """Return the current quarter # of a datetime object as an integer [1..4].
+
+    Jan, Feb, Mar: 1
+    Apr, May, Jun: 2
+    Jul, Aug, Sep: 3
+    Oct, Nov, Dec: 4
+
+    https://stackoverflow.com/a/1406182/3061818
+    """
+    return ((dt.month - 1) // 3) + 1
+
+
+def quarter_start(dt):
+    """Return datetime object for date/time of start of quarter."""
+    q = quarter(dt)
+    return datetime.datetime(year=dt.year,
+                             month=(q * 3) - 2,
+                             day=1,
+                             tzinfo=dt.tzinfo)
+
+
+def quarter_end(dt):
+    """Return datetime object for date/time of end of quarter.
+
+    Probably seems a little roundabout, but conceptually easy.
+
+     - Find start of current quarter
+     - Add 100 days, we'll be in next quarter (since there's at most 92
+       days in a quarter)
+     - Find the end of the "previous quarter of the next quarter."
+    """
+    date_in_next_quarter = quarter_start(dt) + datetime.timedelta(days=100)
+    return prev_quarter_end(date_in_next_quarter)
+
+
+def prev_quarter_start(dt):
+    """Return datetime object for date/time of start of previous quarter."""
+    return quarter_start(prev_quarter_end(dt))
+
+
+def prev_quarter_end(dt):
+    """Return datetime object for date/time of end of previous quarter."""
+    curr_start = quarter_start(dt)
+    prev_end = curr_start - datetime.timedelta(days=1)
+    return prev_end.replace(hour=23, minute=59, second=59, microsecond=99999)

--- a/bf_opencore/views/group.py
+++ b/bf_opencore/views/group.py
@@ -12,8 +12,7 @@ from rest_framework.decorators import action
 from waffle.mixins import WaffleSwitchMixin
 
 from bf_opencore.models import Group, Asset, AssetGroup
-
-from utils import iterable
+from bf_opencore.utils import iterable
 from .utils import HugeLimitOffsetPagination
 
 logger = logging.getLogger(__name__)

--- a/bf_opencore/views/network.py
+++ b/bf_opencore/views/network.py
@@ -10,7 +10,7 @@ from rest_framework.decorators import action
 from waffle.mixins import WaffleSwitchMixin
 
 from bf_opencore.models import Network, SavedSearch, Asset, Cidr
-from utils import ipset_from_network
+from bf_opencore.utils import ipset_from_network
 
 logger = logging.getLogger(__name__)
 

--- a/bf_opencore/views/tag.py
+++ b/bf_opencore/views/tag.py
@@ -13,8 +13,7 @@ from simple_history import utils as hist_utils
 from waffle.mixins import WaffleSwitchMixin
 
 from bf_opencore.models import Tag, Asset, AssetTag
-
-from utils import iterable
+from bf_opencore.utils import iterable
 from .utils import HugeLimitOffsetPagination
 from .utils import ChangeReasonMixin
 

--- a/project/__init__.py
+++ b/project/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2026 Virta Laboratories, Inc.  All rights reserved.
+
+"""Django project configuration for local development and OSS use."""

--- a/project/settings/__init__.py
+++ b/project/settings/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2026 Virta Laboratories, Inc.  All rights reserved.
+
+"""Django settings package. Use project.settings.test for pytest."""

--- a/project/settings/test.py
+++ b/project/settings/test.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2026 Virta Laboratories, Inc.  All rights reserved.
 
-"""Minimal Django settings for running bf-opencore tests (pytest)."""
+"""Minimal Django settings for bf-opencore tests (pytest). Use DJANGO_SETTINGS_MODULE=project.settings.test."""
 
 SECRET_KEY = "test-secret-key-not-for-production"
 DEBUG = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,5 @@ dependencies = [
     "django>=5.2,<5.3",
     "djangorestframework>=3.16,<3.17",
     "drf-spectacular<=0.29",
+    "netaddr>=0.10.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ dependencies = [
     "drf-spectacular<=0.29",
     "netaddr>=0.10.0",
 ]
+
+[tool.setuptools.packages.find]
+include = ["bf_opencore*"]

--- a/scripts/discover_bf_app.py
+++ b/scripts/discover_bf_app.py
@@ -1,0 +1,21 @@
+#! /usr/bin/env python3
+"""Discover BlueFlow app in Django settings."""
+# Copyright (C) 2026 Virta Laboratories, Inc.  All rights reserved.
+
+import os
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django.conf.global_settings")
+from django.conf import global_settings
+
+global_settings.INSTALLED_APPS = list(global_settings.INSTALLED_APPS) + [
+    "blueflow.apps.BlueflowConfig"
+]
+
+django.setup()
+
+from django.apps import apps
+
+config = apps.get_app_config("blueflow")
+assert config.__class__.__name__ == "BlueflowConfig"
+print("Blueflow app is discoverable:", config.name, config.verbose_name)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for bf-opencore (blueflow package).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 
 def pytest_configure(config):
     """Set Django settings module for pytest-django before Django is loaded."""
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings.test")
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2026 Virta Laboratories, Inc.  All rights reserved.
+
+"""Pytest configuration for bf-opencore tests."""
+
+import os
+
+import pytest
+
+
+def pytest_configure(config):
+    """Set Django settings module for pytest-django before Django is loaded."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
+
+
+@pytest.fixture(scope="session")
+def django_db_setup():
+    """Use in-memory SQLite for tests (no DB file)."""
+    pass

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2026 Virta Laboratories, Inc.  All rights reserved.
+
+"""Minimal Django settings for running bf-opencore tests (pytest)."""
+
+SECRET_KEY = "test-secret-key-not-for-production"
+DEBUG = True
+ALLOWED_HOSTS = ["*"]
+
+INSTALLED_APPS = [
+    "blueflow.apps.BlueflowConfig",
+    "blueflow.connectors.apps.BlueflowConnectorConfig",
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.humanize",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "django_celery_beat",
+    "django_filters",
+    "django_jsx",
+    "netfields",
+    "rest_framework",
+    "rest_framework.authtoken",
+    "drf_spectacular",
+    "simple_history",
+    "waffle",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "simple_history.middleware.HistoryRequestMiddleware",
+    "waffle.middleware.WaffleMiddleware",
+]
+
+ROOT_URLCONF = "blueflow.urls"
+WSGI_APPLICATION = None
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.TokenAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
+    ],
+}

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -28,6 +27,7 @@ dependencies = [
     { name = "django" },
     { name = "djangorestframework" },
     { name = "drf-spectacular" },
+    { name = "netaddr" },
 ]
 
 [package.metadata]
@@ -35,6 +35,7 @@ requires-dist = [
     { name = "django", specifier = ">=5.2,<5.3" },
     { name = "djangorestframework", specifier = ">=3.16,<3.17" },
     { name = "drf-spectacular", specifier = "<=0.29" },
+    { name = "netaddr", specifier = ">=0.10.0" },
 ]
 
 [[package]]
@@ -114,6 +115,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437 },
+]
+
+[[package]]
+name = "netaddr"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/90/188b2a69654f27b221fba92fda7217778208532c962509e959a9cee5229d/netaddr-1.3.0.tar.gz", hash = "sha256:5c3c3d9895b551b763779ba7db7a03487dc1f8e3b385af819af341ae9ef6e48a", size = 2260504 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cc/f4fe2c7ce68b92cbf5b2d379ca366e1edae38cccaad00f69f529b460c3ef/netaddr-1.3.0-py3-none-any.whl", hash = "sha256:c2c6a8ebe5554ce33b7d5b3a306b71bbb373e000bbbf2350dd5213cc56e3dbbe", size = 2262023 },
 ]
 
 [[package]]


### PR DESCRIPTION
- **chore(bf_opencore): make library self-contained**
  Create bf_opencore.utils package and remove dependencies on project-level
  utils and proprietary blueflow package. All runtime code now uses
  bf_opencore.utils and bf_opencore.exceptions, making the library
  independently distributable.
  
  - Add blueflow/ to .gitignore
  - Create bf_opencore/utils with required utilities
  - Fix imports in 10 files (models and views)
  - Add netaddr dependency
  

- **chore: add project/ and move test settings to project.settings.test**
  - Add project/ with project/settings/ for Django project config
  - Move tests/settings.py to project/settings/test.py
  - Set DJANGO_SETTINGS_MODULE to project.settings.test in tests/conftest.py
  - Restrict setuptools to bf_opencore* so project/ is not packaged
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Consolidated internal import paths to use `bf_opencore` namespace consistently across modules.
  * Updated `.gitignore` to exclude proprietary code directories.
  * Enhanced packaging configuration for proper module discovery.

* **Infrastructure**
  * Added pytest configuration for test environment with in-memory database.
  * Added new utility modules for IP set handling, quarter calculations, and Django signal management.
  * Added `netaddr` dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->