### PR TITLE
fix: Always run uv sync in entrypoint so web_venv stays in sync with lockfile

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,9 +3,6 @@
 # Run migrations then exec the container command (e.g. runserver).
 
 set -e
-# When docker-compose mounts .:/app, the host .venv may have invalid paths; ensure a working venv.
-if ! /app/.venv/bin/python -c "import sys" 2>/dev/null; then
-  uv sync --frozen --no-dev
-fi
+uv sync --frozen --no-dev
 /app/.venv/bin/python project/manage.py migrate --noinput
 exec "$@"


### PR DESCRIPTION
## Problem

The previous entrypoint only ran `uv sync` when the venv's Python failed `import sys`. A venv that passes that check but is missing packages was never repaired.

## Solution

Always run `uv sync --frozen --no-dev` at entrypoint start, before migrations and the app command. The venv in the `web_venv` volume then stays in sync with `uv.lock` on every container start, so added or updated dependencies are always present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined Docker container startup process by removing environment validation checks. The dependency synchronization now runs unconditionally during container initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->