### PR TITLE
feat: replace upsert endpoint with bulk PATCH ListView

### DIFF
--- a/blueflow/conftest.py
+++ b/blueflow/conftest.py
@@ -1,13 +1,7 @@
 import django.core.management
 import pytest
-from rest_framework.test import APIClient
 
 from blueflow.celery import celery_app as cp
-
-
-@pytest.fixture
-def auth_client():
-    return APIClient()
 
 
 @pytest.fixture

--- a/blueflow/models/asset.py
+++ b/blueflow/models/asset.py
@@ -742,17 +742,11 @@ class Asset(models.Model):
         return f"{self.id}:{self.display_name}:{self.ip_address}"
 
     def todict(self):
-        """Return all fields as a dictionary of field name -> field value."""
-        # TODO: Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("To dict is not implemented")
-        output = {f.name: getattr(self, f.name, None) for f in Asset._meta.get_fields()}
-        output["asset_risk_factors"] = {
-            x.risk_factor.name: x.value for x in self.asset_risk_factors.all()
-        }
-        output["asset_custom_fields"] = {
-            x.field.field_name: x.value_text for x in self.asset_custom_fields.all()
-        }
-        return output
+        """Return concrete fields as a dictionary for diffing in update_or_create.
+
+        Ported from experimental/testbed-build:bf_opencore/models/asset.py.
+        """
+        return {f.name: getattr(self, f.attname, None) for f in self._meta.fields}  # noqa: SLF001
 
     def needs_sw_update(self):
         """Return whether this asset needs a software update.

--- a/blueflow/tests/test_asset.py
+++ b/blueflow/tests/test_asset.py
@@ -1186,6 +1186,20 @@ def test_bulk_update_non_list_returns_400(asset_edit_client: APIClient) -> None:
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
+def test_bulk_update_duplicate_id_returns_400(asset_edit_client: APIClient) -> None:
+    """PATCH /api/assets/bulk_update/ returns 400 if the same id appears twice."""
+    asset = models.Asset.objects.create(hostname="device-a")
+    response = asset_edit_client.patch(
+        "/api/assets/bulk_update/",
+        json.dumps([
+            {"id": asset.id, "hostname": "first"},
+            {"id": asset.id, "hostname": "second"},
+        ]),
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
 def test_bulk_update_idempotent(asset_edit_client: APIClient) -> None:
     """Sending the same PATCH twice produces the same result."""
     asset = models.Asset.objects.create(hostname="original")

--- a/blueflow/tests/test_asset.py
+++ b/blueflow/tests/test_asset.py
@@ -8,40 +8,40 @@ import json
 
 import django
 import pytest
-
 from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.test import APIClient
 
 from blueflow import models
 
 
-def test_get_empty_assets(auth_client):
+def test_get_empty_assets(auth_client: APIClient) -> None:
     """Test that asset list is empty unless we do something special."""
     assets = auth_client.get("/api/assets/")
     assert assets.data["count"] == 0
 
 
-def test_create_asset(auth_client):
+def test_create_asset(auth_client: APIClient) -> None:
     """Creating an empty asset makes it available via the API."""
     _ = models.Asset.objects.create()
     assets = auth_client.get("/api/assets/")
-    assert assets.status_code == 200
+    assert assets.status_code == status.HTTP_200_OK
     assert assets.data["count"] == 1
 
 
-def test_get_asset_csv(auth_client):
+def test_get_asset_csv(auth_client: APIClient) -> None:
     """We can specify CSV format."""
     _ = models.Asset.objects.create()
-    # import pdb ; pdb.set_trace()
     response = auth_client.get("/api/assets/", HTTP_ACCEPT="text/csv")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.data["count"] == 1
-    assert len(response.content.splitlines()) == 2  # header row + 1 asset
+    header_count = 2  # header row + 1 asset
+    assert len(response.content.splitlines()) == header_count
 
 
-def test_get_asset_csv_specify_fields(auth_client):
+def test_get_asset_csv_specify_fields(auth_client: APIClient) -> None:
     """With CSV format we generally would specify which headers we want."""
     _ = models.Asset.objects.create(name="spam", ip_address="10.0.0.1")
-    # import pdb ; pdb.set_trace()
     response = auth_client.get(
         "/api/assets/?fields=name,ip_address,model", HTTP_ACCEPT="text/csv"
     )
@@ -53,17 +53,16 @@ def test_get_asset_csv_specify_fields(auth_client):
     assert asset == ["spam", "10.0.0.1", ""]
 
 
-def test_export_assets_json(auth_client):
+def test_export_assets_json(auth_client: APIClient) -> None:
     """We can export assets to JSON."""
     _ = models.Asset.objects.create()
-    # import pdb ; pdb.set_trace()
     response = auth_client.get("/api/assets/", HTTP_ACCEPT="application/json")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.data["count"] == 1
     assert json.loads(response.content)
 
 
-def test_api_create_asset(asset_edit_client):
+def test_api_create_asset(asset_edit_client: APIClient) -> None:
     """Create an asset with authorized client."""
     client = asset_edit_client
     response = client.post(
@@ -71,14 +70,14 @@ def test_api_create_asset(asset_edit_client):
         json.dumps({"hostname": "nospam"}),
         content_type="application/json",
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assets = client.get("/api/assets/")
     assert assets.data["count"] == 1
     asset = assets.data["results"].pop()
     assert asset["hostname"] == "nospam"
 
 
-def test_api_create_asset_maconly(asset_edit_client):
+def test_api_create_asset_maconly(asset_edit_client: APIClient) -> None:
     """Create an asset with authorized client."""
     client = asset_edit_client
     response = client.post(
@@ -86,14 +85,14 @@ def test_api_create_asset_maconly(asset_edit_client):
         json.dumps({"mac_address": "1"}),
         content_type="application/json",
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assets = client.get("/api/assets/")
     assert assets.data["count"] == 1
     asset = assets.data["results"].pop()
     assert asset["mac_address"] == "00:00:00:00:00:01"
 
 
-def test_api_create_asset_addinventory_maconly(asset_edit_client):
+def test_api_create_asset_addinventory_maconly(asset_edit_client: APIClient) -> None:
     """Create an asset, replicating 'add inventory.
 
     This replicates 'add inventory' where the IP address is empty -- it
@@ -105,7 +104,7 @@ def test_api_create_asset_addinventory_maconly(asset_edit_client):
         json.dumps({"mac_address": "1", "ip_address": ""}),
         content_type="application/json",
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assets = client.get("/api/assets/")
     assert assets.data["count"] == 1
     asset = assets.data["results"].pop()
@@ -113,7 +112,7 @@ def test_api_create_asset_addinventory_maconly(asset_edit_client):
     assert asset["ip_address"] is None
 
 
-def test_api_create_asset_addinventory_empty_mac(asset_edit_client):
+def test_api_create_asset_addinventory_empty_mac(asset_edit_client: APIClient) -> None:
     """Create an asset, replicating 'add inventory.
 
     This replicates 'add inventory' where the MAC address is empty -- it
@@ -125,7 +124,7 @@ def test_api_create_asset_addinventory_empty_mac(asset_edit_client):
         json.dumps({"mac_address": "", "ip_address": ""}),
         content_type="application/json",
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assets = client.get("/api/assets/")
     assert assets.data["count"] == 1
     asset = assets.data["results"].pop()
@@ -133,7 +132,9 @@ def test_api_create_asset_addinventory_empty_mac(asset_edit_client):
     assert asset["ip_address"] is None
 
 
-def test_api_create_asset_addinventory_empty_mac_times_two(asset_edit_client):
+def test_api_create_asset_addinventory_empty_mac_times_two(
+    asset_edit_client: APIClient,
+) -> None:
     """Create an asset, replicating 'add inventory'.
 
     This replicates 'add inventory' where the MAC address is empty, and
@@ -147,7 +148,7 @@ def test_api_create_asset_addinventory_empty_mac_times_two(asset_edit_client):
         json.dumps({"mac_address": "", "ip_address": ""}),
         content_type="application/json",
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assets = client.get("/api/assets/")
     assert assets.data["count"] == 1
     # Create the second asset
@@ -156,12 +157,12 @@ def test_api_create_asset_addinventory_empty_mac_times_two(asset_edit_client):
         json.dumps({"mac_address": "", "ip_address": ""}),
         content_type="application/json",
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assets = client.get("/api/assets/")
-    assert assets.data["count"] == 2
+    assert assets.data["count"] == 2  # noqa: PLR2004
 
 
-def test_api_create_asset_unauthorized(auth_client):
+def test_api_create_asset_unauthorized(auth_client: APIClient) -> None:
     """Can't create an asset with an unauthorized client."""
     client = auth_client
     response = client.post(
@@ -169,27 +170,29 @@ def test_api_create_asset_unauthorized(auth_client):
         json.dumps({"hostname": "nospam"}),
         content_type="application/json",
     )
-    assert response.status_code == 403  # 403 = Not permitted
+    assert response.status_code == status.HTTP_403_FORBIDDEN
     assets = client.get("/api/assets/")
     assert assets.data["count"] == 0
     assert len(assets.data["results"]) == 0
 
 
-def test_api_create_get_asset(auth_client, asset_edit_client):
+def test_api_create_get_asset(
+    auth_client: APIClient, asset_edit_client: APIClient
+) -> None:
     """Create an asset, read with less-authorized client."""
     response = asset_edit_client.post(
         "/api/assets/",
         json.dumps({"hostname": "nospam"}),
         content_type="application/json",
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assets = auth_client.get("/api/assets/")
     assert assets.data["count"] == 1
     asset = assets.data["results"].pop()
     assert asset["hostname"] == "nospam"
 
 
-def test_api_create_asset_open_ports(asset_edit_client):
+def test_api_create_asset_open_ports(asset_edit_client: APIClient) -> None:
     """Create an asset with authorized client.
 
     As if from http://localhost:8000/inventory/add/.
@@ -199,21 +202,23 @@ def test_api_create_asset_open_ports(asset_edit_client):
     response = client.post(
         "/api/assets/", json.dumps(post_data), content_type="application/json"
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assets = client.get("/api/assets/")
     assert assets.data["count"] == 1
     asset = assets.data["results"].pop()
     assert asset["open_ports_tcp"] == [80, 443, 8000]
 
 
-def test_api_create_patch_asset(auth_client, asset_edit_client):
+def test_api_create_patch_asset(
+    auth_client: APIClient, asset_edit_client: APIClient
+) -> None:
     """Create an asset, then patch."""
     response = asset_edit_client.post(
         "/api/assets/",
         json.dumps({"hostname": "nospam"}),
         content_type="application/json",
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.data["hostname"] == "nospam"
     asset_id = response.data["id"]
     response = asset_edit_client.patch(
@@ -221,7 +226,7 @@ def test_api_create_patch_asset(auth_client, asset_edit_client):
         json.dumps({"hostname": "spam"}),
         content_type="application/json",
     )
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.data["hostname"] == "spam"
     assets = auth_client.get("/api/assets/")
     assert assets.data["count"] == 1
@@ -229,7 +234,7 @@ def test_api_create_patch_asset(auth_client, asset_edit_client):
     assert asset["hostname"] == "spam"
 
 
-def test_api_create_asset_displayname(asset_edit_client):
+def test_api_create_asset_displayname(asset_edit_client: APIClient) -> None:
     """Create an asset with a display_name."""
     client = asset_edit_client
     response = client.post(
@@ -237,12 +242,12 @@ def test_api_create_asset_displayname(asset_edit_client):
         json.dumps({"display_name": "foobar"}),
         content_type="application/json",
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.data["name"] == "foobar"
     assert response.data["display_name"] == "foobar"
 
 
-def test_api_create_asset_displayname_name(asset_edit_client):
+def test_api_create_asset_displayname_name(asset_edit_client: APIClient) -> None:
     """Create an asset with a display_name *and* a name.
 
     The display_name provided will be favoured.
@@ -257,12 +262,12 @@ def test_api_create_asset_displayname_name(asset_edit_client):
         json.dumps({"name": "foobaz", "display_name": "foobar"}),
         content_type="application/json",
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.data["name"] == "foobar"  # NOTE: display_name is favored
     assert response.data["display_name"] == "foobar"
 
 
-def test_api_create_asset_displayname_name_2(asset_edit_client):
+def test_api_create_asset_displayname_name_2(asset_edit_client: APIClient) -> None:
     """Create an asset with a display_name *and* a name.
 
     Like the test above, but order of name/display name is reversed.
@@ -274,12 +279,12 @@ def test_api_create_asset_displayname_name_2(asset_edit_client):
         json.dumps({"display_name": "foobar", "name": "foobaz"}),
         content_type="application/json",
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.data["name"] == "foobar"  # NOTE: display_name is favored
     assert response.data["display_name"] == "foobar"
 
 
-def test_api_update_asset_displayname(asset_edit_client):
+def test_api_update_asset_displayname(asset_edit_client: APIClient) -> None:
     """Create an asset, update display_name later."""
     client = asset_edit_client
     response = client.post(
@@ -293,7 +298,7 @@ def test_api_update_asset_displayname(asset_edit_client):
         json.dumps({"display_name": "spam"}),
         content_type="application/json",
     )
-    assert response.status_code == 200  # 200 = Updated
+    assert response.status_code == status.HTTP_200_OK
     assert response.data["name"] == "spam"
     assert response.data["display_name"] == "spam"
 
@@ -303,7 +308,9 @@ def test_api_update_asset_displayname(asset_edit_client):
     reason="Not sure why, but we *are* allowed to patch.  "
     "Maybe there's a mix-up re: which user is which.",
 )
-def test_api_create_unauth_patch_asset(auth_client, asset_edit_client):
+def test_api_create_unauth_patch_asset(
+    auth_client: APIClient, asset_edit_client: APIClient
+) -> None:
     """Create an asset, patch with less-authorized client...
 
     ... except it fails.  See test_authentication.py::test_perm_auth_clients
@@ -318,7 +325,7 @@ def test_api_create_unauth_patch_asset(auth_client, asset_edit_client):
         json.dumps({"hostname": "nospam"}),
         content_type="application/json",
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.data["hostname"] == "nospam"
     asset_id = response.data["id"]
     response = auth_client.patch(
@@ -326,21 +333,21 @@ def test_api_create_unauth_patch_asset(auth_client, asset_edit_client):
         json.dumps({"hostname": "spam"}),
         content_type="application/json",
     )
-    assert response.status_code == 403  # <- this fails...
+    assert response.status_code == status.HTTP_403_FORBIDDEN  # <- this fails...
     assets = auth_client.get("/api/assets/")
     assert assets.data["count"] == 1
     asset = assets.data["results"].pop()
     assert asset["hostname"] == "nospam"
 
 
-def test_unauth_patch_asset(auth_client):
+def test_unauth_patch_asset(auth_client: APIClient) -> None:
     """Create an asset, patch with less-authorized client.
 
     (auth_client is 'authenticated', not 'authorized')
     """
     _ = models.Asset.objects.create()
     response = auth_client.get("/api/assets/")
-    assert response.status_code == 200  # 200 = Created
+    assert response.status_code == status.HTTP_200_OK
     assert response.json()["count"] == 1
     asset = response.json()["results"][0]
     assert asset["hostname"] is None
@@ -349,15 +356,15 @@ def test_unauth_patch_asset(auth_client):
         json.dumps({"hostname": "spam"}),
         content_type="application/json",
     )
-    assert response.status_code == 403
+    assert response.status_code == status.HTTP_403_FORBIDDEN
     response = auth_client.get("/api/assets/")
-    assert response.status_code == 200  # 200 = Created
+    assert response.status_code == status.HTTP_200_OK
     assert response.json()["count"] == 1
     asset = response.json()["results"][0]
     assert asset["hostname"] is None  # Still None
 
 
-def test_create_many_assets(auth_client):
+def test_create_many_assets(auth_client: APIClient) -> None:
     """Creating multiple assets makes them available via the API."""
     asset_names = ["foo", "bar", "baz", "xyzzy", "spam", "ham", "eggs"]
     for name in asset_names:
@@ -366,7 +373,7 @@ def test_create_many_assets(auth_client):
     assert assets.data["count"] == len(asset_names)
 
 
-def test_retrieve_one_asset(auth_client):
+def test_retrieve_one_asset(auth_client: APIClient) -> None:
     """Creating an asset makes it available via the API."""
     asset_names = ["foo", "bar", "baz", "xyzzy", "spam", "ham", "eggs"]
     for hostname in asset_names:
@@ -376,7 +383,7 @@ def test_retrieve_one_asset(auth_client):
     assert len(assets.data["results"]) == 1
 
 
-def test_one_asset_details(auth_client):
+def test_one_asset_details(auth_client: APIClient) -> None:
     """Creating an asset makes its details available via the API."""
     asset_names = ["foo", "bar", "baz", "xyzzy", "spam", "ham", "eggs"]
     for hostname in asset_names:
@@ -387,7 +394,7 @@ def test_one_asset_details(auth_client):
     assert asset["hostname"] == "xyzzy"
 
 
-def test_patch_asset(asset_edit_client):
+def test_patch_asset(asset_edit_client: APIClient) -> None:
     """Patching an asset field updates the asset in the database."""
     client = asset_edit_client
     spam_asset = models.Asset.objects.create(hostname="spam")
@@ -405,7 +412,7 @@ def test_patch_asset(asset_edit_client):
     assert spam_asset.hostname == "nospam"
 
 
-def test_patch_asset_open_ports_tcp_string(asset_edit_client):
+def test_patch_asset_open_ports_tcp_string(asset_edit_client: APIClient) -> None:
     """Patching ports with a string of integers.
 
     We try to be helpful, and sort the resulting list & make it unique.
@@ -424,7 +431,7 @@ def test_patch_asset_open_ports_tcp_string(asset_edit_client):
         json.dumps({"open_ports_tcp": port_string}),
         content_type="application/json",
     )
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     # Query for the new version of spam_asset, verify that the list of
     # ports is correct.
     spam_asset = models.Asset.objects.get(id=spam_asset.id)
@@ -432,7 +439,7 @@ def test_patch_asset_open_ports_tcp_string(asset_edit_client):
     assert spam_asset.open_ports_tcp == [80, 443, 8000]
 
 
-def test_patch_asset_open_ports_tcp_list(asset_edit_client):
+def test_patch_asset_open_ports_tcp_list(asset_edit_client: APIClient) -> None:
     """Patching ports with a string of integers.
 
     We try to be helpful, and sort the resulting list & make it unique.
@@ -450,7 +457,7 @@ def test_patch_asset_open_ports_tcp_list(asset_edit_client):
         json.dumps({"open_ports_tcp": port_list}),
         content_type="application/json",
     )
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     # Query for the new version of spam_asset, verify that the list of
     # ports is correct.
     spam_asset = models.Asset.objects.get(id=spam_asset.id)
@@ -458,7 +465,7 @@ def test_patch_asset_open_ports_tcp_list(asset_edit_client):
     assert spam_asset.open_ports_tcp == [80, 443, 8000]
 
 
-def test_patch_asset_open_ports_tcp_list_bad(asset_edit_client):
+def test_patch_asset_open_ports_tcp_list_bad(asset_edit_client: APIClient) -> None:
     """Patching ports with a string of integers.
 
     We try to be helpful, and sort the resulting list & make it unique.
@@ -476,10 +483,10 @@ def test_patch_asset_open_ports_tcp_list_bad(asset_edit_client):
         json.dumps({"open_ports_tcp": port_list}),
         content_type="application/json",
     )
-    assert response.status_code == 400
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_patch_asset_open_ports_tcp_bad(asset_edit_client):
+def test_patch_asset_open_ports_tcp_bad(asset_edit_client: APIClient) -> None:
     """Patching ports with a string of integers... but they are bad."""
     client = asset_edit_client
     spam_asset = models.Asset.objects.create(hostname="spam")
@@ -493,7 +500,7 @@ def test_patch_asset_open_ports_tcp_bad(asset_edit_client):
         json.dumps({"open_ports_tcp": port_string}),
         content_type="application/json",
     )
-    assert response.status_code == 400
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
     # Query for the new version of spam_asset, verify that the list of
     # ports is correct.
     spam_asset = models.Asset.objects.get(id=spam_asset.id)
@@ -501,7 +508,7 @@ def test_patch_asset_open_ports_tcp_bad(asset_edit_client):
     assert spam_asset.open_ports_tcp == []
 
 
-def test_patch_asset_open_ports_tcp_null(asset_edit_client):
+def test_patch_asset_open_ports_tcp_null(asset_edit_client: APIClient) -> None:
     """Patching ports with Null sets the port list to empty.
 
     We try to be helpful, and sort the resulting list & make it unique.
@@ -518,7 +525,7 @@ def test_patch_asset_open_ports_tcp_null(asset_edit_client):
         json.dumps({"open_ports_tcp": port_string}),
         content_type="application/json",
     )
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     # Query for the new version of spam_asset, verify that the list of
     # ports is correct.
     spam_asset = models.Asset.objects.get(id=spam_asset.id)
@@ -526,7 +533,7 @@ def test_patch_asset_open_ports_tcp_null(asset_edit_client):
     assert spam_asset.open_ports_tcp == []
 
 
-def test_patch_asset_open_ports_tcp_empty(asset_edit_client):
+def test_patch_asset_open_ports_tcp_empty(asset_edit_client: APIClient) -> None:
     """Patching with empty string sets the port list to empty.
 
     We try to be helpful, and sort the resulting list & make it unique.
@@ -543,7 +550,7 @@ def test_patch_asset_open_ports_tcp_empty(asset_edit_client):
         json.dumps({"open_ports_tcp": port_string}),
         content_type="application/json",
     )
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     # Query for the new version of spam_asset, verify that the list of
     # ports is correct.
     spam_asset = models.Asset.objects.get(id=spam_asset.id)
@@ -551,7 +558,7 @@ def test_patch_asset_open_ports_tcp_empty(asset_edit_client):
     assert spam_asset.open_ports_tcp == []
 
 
-def test_set_name_empty(asset_edit_client):
+def test_set_name_empty(asset_edit_client: APIClient) -> None:
     """PATCHing a hostname to an empty string works."""
     client = asset_edit_client
     spam_asset = models.Asset.objects.create(hostname="spam")
@@ -569,7 +576,7 @@ def test_set_name_empty(asset_edit_client):
     assert spam_asset.hostname == ""
 
 
-def test_set_name_null(asset_edit_client):
+def test_set_name_null(asset_edit_client: APIClient) -> None:
     """PATCHing a hostname to `null` works."""
     client = asset_edit_client
     spam_asset = models.Asset.objects.create(hostname="spam")
@@ -581,14 +588,14 @@ def test_set_name_null(asset_edit_client):
         json.dumps({"hostname": None}),
         content_type="application/json",
     )
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     # Query for the new version of spam_asset, verify that its
     # hostname has changed.
     spam_asset = models.Asset.objects.get(id=spam_asset.id)
     assert spam_asset.hostname is None
 
 
-def test_field_histogram(auth_client):
+def test_field_histogram(auth_client: APIClient) -> None:
     """Field histogram works with one field."""
     models.Asset.objects.create(manufacturer="Bar")
     models.Asset.objects.create(manufacturer="Quux")
@@ -598,30 +605,32 @@ def test_field_histogram(auth_client):
     models.Asset.objects.create(manufacturer="Foo")
 
     response = auth_client.get("/api/assets/histogram/", {"field": "manufacturer"})
+
     qset = response.data
 
-    assert len(qset) == 3
+    expected_count = 3
+    assert len(qset) == expected_count
     # Order matters: the histogram is explicitly ordered by highest-count first
     assert [x["manufacturer"] for x in qset] == ["Foo", "Bar", "Quux"]
     assert [x["count"] for x in qset] == [3, 2, 1]
 
 
-def test_field_histogram_no_field(auth_client):
-    """Fail to specify field=<Asset field name> specified: HTTP 400"""
+def test_field_histogram_no_field(auth_client: APIClient) -> None:
+    """Fail to specify field=<Asset field name>: HTTP 400."""
     response = auth_client.get("/api/assets/histogram/")
-    assert response.status_code == 400
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_field_histogram_no_such_field(auth_client):
-    """Specify field=<nonsense>: HTTP 400"""
+def test_field_histogram_no_such_field(auth_client: APIClient) -> None:
+    """Specify field=<nonsense>: HTTP 400."""
     response = auth_client.get("/api/assets/histogram/", {"field": "asdf"})
-    assert response.status_code == 400
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_api_duplicate_ips(auth_client):
+def test_api_duplicate_ips(auth_client: APIClient) -> None:
     """Check for duplicate IP addresses in the asset population."""
     response = auth_client.get("/api/assets/duplicate_ips/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == []
 
     models.Asset.objects.create(ip_address="1.2.3.4")
@@ -631,17 +640,17 @@ def test_api_duplicate_ips(auth_client):
     models.Asset.objects.create(ip_address="1.2.3.5")
     models.Asset.objects.create(manufacturer="Foo", ip_address=None)
     response = auth_client.get("/api/assets/duplicate_ips/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == [
         ["1.2.3.4", 3],
         ["1.2.3.5", 2],
     ]
 
 
-def test_api_duplicate_ips_one(auth_client):
+def test_api_duplicate_ips_one(auth_client: APIClient) -> None:
     """Check for duplicate IP addresses in the asset population."""
     response = auth_client.get("/api/assets/duplicate_ips/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == []
 
     models.Asset.objects.create(ip_address="1.2.3.4")
@@ -651,7 +660,7 @@ def test_api_duplicate_ips_one(auth_client):
     models.Asset.objects.create(ip_address="1.2.3.5")
     models.Asset.objects.create(manufacturer="Foo", ip_address=None)
     response = auth_client.get("/api/assets/duplicate_ips/?ip_address=1.2.3.4")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == [
         ["1.2.3.4", 3],
     ]
@@ -661,10 +670,10 @@ def test_api_duplicate_ips_one(auth_client):
     raises=AssertionError,
     reason="not allowed to spell out 'exact' in URL for some reason.",
 )
-def test_api_duplicate_ips_one_spell_exact(auth_client):
+def test_api_duplicate_ips_one_spell_exact(auth_client: APIClient) -> None:
     """Check for duplicate IP addresses in the asset population."""
     response = auth_client.get("/api/assets/duplicate_ips/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == []
 
     models.Asset.objects.create(ip_address="1.2.3.4")
@@ -674,16 +683,16 @@ def test_api_duplicate_ips_one_spell_exact(auth_client):
     models.Asset.objects.create(ip_address="1.2.3.5")
     models.Asset.objects.create(manufacturer="Foo", ip_address=None)
     response = auth_client.get("/api/assets/duplicate_ips/?ip_address__exact=1.2.3.4")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == [
         ["1.2.3.4", 3],
     ]
 
 
-def test_api_duplicate_ips_one_prefix_robust(auth_client):
+def test_api_duplicate_ips_one_prefix_robust(auth_client: APIClient) -> None:
     """Check for duplicate IP addresses in the asset population."""
     response = auth_client.get("/api/assets/duplicate_ips/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == []
 
     models.Asset.objects.create(ip_address="1.2.3.4")
@@ -695,40 +704,42 @@ def test_api_duplicate_ips_one_prefix_robust(auth_client):
     models.Asset.objects.create(ip_address="1.2.3.5")
     models.Asset.objects.create(manufacturer="Foo", ip_address=None)
     response = auth_client.get("/api/assets/duplicate_ips/?ip_address=1.2.3.4")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == [
         ["1.2.3.4", 3],
     ]
 
 
-def test_fetch_by_os(auth_client):
+def test_fetch_by_os(auth_client: APIClient) -> None:
     """Assets can be fetched by OS field."""
     a1 = models.Asset.objects.create(os="Windows XP")
     a2 = models.Asset.objects.create(os="WinXP")
     a3 = models.Asset.objects.create(os="XP")
 
     response = auth_client.get("/api/assets/?os__iexact=XP")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     js = response.json()
     assert js["count"] == 1
     assert js["results"][0]["id"] == a3.id
 
     response = auth_client.get("/api/assets/?os__icontains=XP")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     js = response.json()
-    assert js["count"] == 3
-    ids = set(x["id"] for x in js["results"])
-    assert ids == set([a1.id, a2.id, a3.id])
+    expected_count = 3
+    assert js["count"] == expected_count
+    ids = {x["id"] for x in js["results"]}
+    assert ids == {a1.id, a2.id, a3.id}
 
     response = auth_client.get("/api/assets/?os__istartswith=win")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     js = response.json()
-    assert js["count"] == 2
-    ids = set(x["id"] for x in js["results"])
-    assert ids == set([a1.id, a2.id])
+    expected_count_2 = 2
+    assert js["count"] == expected_count_2
+    ids = {x["id"] for x in js["results"]}
+    assert ids == {a1.id, a2.id}
 
 
-def test_app_sw_version_needs_update(auth_client):
+def test_app_sw_version_needs_update(auth_client: APIClient) -> None:
     """Test whether assets need software updates."""
     oldest = models.Asset.objects.create(
         manufacturer="Foo", model="Bar", app_sw_version="1.2.3"
@@ -741,22 +752,22 @@ def test_app_sw_version_needs_update(auth_client):
     )
 
     response = auth_client.get(f"/api/assets/{oldest.id}/needs_sw_update/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json()["latest"] == newest.app_sw_version
     assert response.json()["needs_update"] is True
 
     response = auth_client.get(f"/api/assets/{newer.id}/needs_sw_update/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json()["latest"] == newest.app_sw_version
     assert response.json()["needs_update"] is True
 
     response = auth_client.get(f"/api/assets/{newest.id}/needs_sw_update/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json()["latest"] == newest.app_sw_version
     assert response.json()["needs_update"] is False
 
 
-def test_nonsense_app_sw_version_needs_update(auth_client):
+def test_nonsense_app_sw_version_needs_update(auth_client: APIClient) -> None:
     """Test whether a silly asset needs an update."""
     a = models.Asset.objects.create(
         manufacturer="Foo", model="Bar", app_sw_version="Henrik Holm"
@@ -772,7 +783,7 @@ def test_nonsense_app_sw_version_needs_update(auth_client):
     assert resp.json()["needs_update"] is True
 
 
-def test_app_sw_version_not_needs_update(auth_client):
+def test_app_sw_version_not_needs_update(auth_client: APIClient) -> None:
     """Test whether two equal assets need updates."""
     a1 = models.Asset.objects.create(
         manufacturer="Foo", model="Bar", app_sw_version="1.2.3"
@@ -783,24 +794,24 @@ def test_app_sw_version_not_needs_update(auth_client):
 
     response1 = auth_client.get(f"/api/assets/{a1.id}/needs_sw_update/")
     response2 = auth_client.get(f"/api/assets/{a2.id}/needs_sw_update/")
-    assert response1.status_code == response2.status_code == 200
+    assert response1.status_code == response2.status_code == status.HTTP_200_OK
     assert response1.json()["latest"] == "1.2.3"
     assert response1.json()["needs_update"] is False
     assert response2.json()["latest"] == "1.2.3"
     assert response2.json()["needs_update"] is False
 
 
-def test_app_sw_no_version_needs_update(auth_client):
+def test_app_sw_no_version_needs_update(auth_client: APIClient) -> None:
     """Test whether assets without software versions need updates."""
     asset = models.Asset.objects.create(manufacturer="Foo", model="Bar")
     response = auth_client.get(f"/api/assets/{asset.id}/needs_sw_update/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json()["latest"] is None
     assert response.json()["versions_in_use"] == {}
     assert response.json()["needs_update"] is False
 
 
-def test_api_create_asset_mac_autofill_nic(asset_edit_client):
+def test_api_create_asset_mac_autofill_nic(asset_edit_client: APIClient) -> None:
     """Create an asset with NIC vendor."""
     client = asset_edit_client
     response = client.post(
@@ -808,7 +819,7 @@ def test_api_create_asset_mac_autofill_nic(asset_edit_client):
         json.dumps({"mac_address": "34:36:3b:c4:7d:ec"}),
         content_type="application/json",
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assets = client.get("/api/assets/")
     assert assets.data["count"] == 1
     asset = assets.data["results"].pop()
@@ -816,7 +827,7 @@ def test_api_create_asset_mac_autofill_nic(asset_edit_client):
     assert asset["nic_vendor"] == "Apple, Inc."
 
 
-def test_api_create_asset_mac_reject_nic(asset_edit_client):
+def test_api_create_asset_mac_reject_nic(asset_edit_client: APIClient) -> None:
     """Provided NIC vendor will be silently ignored."""
     client = asset_edit_client
     response = client.post(
@@ -829,7 +840,7 @@ def test_api_create_asset_mac_reject_nic(asset_edit_client):
         ),
         content_type="application/json",
     )
-    assert response.status_code == 201  # 201 = Created
+    assert response.status_code == status.HTTP_201_CREATED
     assets = client.get("/api/assets/")
     assert assets.data["count"] == 1
     asset = assets.data["results"].pop()
@@ -837,7 +848,7 @@ def test_api_create_asset_mac_reject_nic(asset_edit_client):
     assert asset["nic_vendor"] == "Apple, Inc."
 
 
-def test_upsert_create(asset_edit_client):
+def test_upsert_create(asset_edit_client: APIClient) -> None:
     """Create a new asset via upsert endpoint."""
     macaddr = "00:03:b1:b5:b6:48"
     response = asset_edit_client.post(
@@ -849,7 +860,7 @@ def test_upsert_create(asset_edit_client):
         ),
         content_type="application/json",
     )
-    assert response.status_code == 201  # Created
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.data["mac_address"] == macaddr
     assert response.data["nic_vendor"] == "Hospira Inc."
     assert models.Asset.objects.count() == 1
@@ -857,7 +868,7 @@ def test_upsert_create(asset_edit_client):
     assert asset.mac_address == macaddr
 
 
-def test_upsert_update(asset_edit_client):
+def test_upsert_update(asset_edit_client: APIClient) -> None:
     """Update an existing asset via upsert endpoint."""
     # Create existing asset in database
     models.Asset.objects.create(mac_address="11:22:33:44:55:66")
@@ -871,7 +882,7 @@ def test_upsert_update(asset_edit_client):
         ),
         content_type="application/json",
     )
-    assert response.status_code == 200  # OK
+    assert response.status_code == status.HTTP_200_OK
     assert response.data["mac_address"] == "11:22:33:44:55:66"
     assert response.data["ip_address"] == "10.0.0.1"
     assert models.Asset.objects.count() == 1
@@ -880,7 +891,7 @@ def test_upsert_update(asset_edit_client):
     assert str(asset.ip_address) == "10.0.0.1"
 
 
-def test_upsert_no_mac_address(asset_edit_client):
+def test_upsert_no_mac_address(asset_edit_client: APIClient) -> None:
     """Upsert endpoint ignores calls that lack a MAC address."""
     response = asset_edit_client.post(
         "/api/assets/upsert/",
@@ -891,11 +902,11 @@ def test_upsert_no_mac_address(asset_edit_client):
         ),
         content_type="application/json",
     )
-    assert response.status_code == 412  # Precondition failed
+    assert response.status_code == status.HTTP_412_PRECONDITION_FAILED
     assert models.Asset.objects.count() == 0
 
 
-def test_upsert_no_mac_address_duplicate(asset_edit_client):
+def test_upsert_no_mac_address_duplicate(asset_edit_client: APIClient) -> None:
     """Call upsert endpoint twice, with the same IP address.
 
     The first call contains a MAC address and creates an asset.  The second
@@ -911,7 +922,7 @@ def test_upsert_no_mac_address_duplicate(asset_edit_client):
         ),
         content_type="application/json",
     )
-    assert response.status_code == 201  # Created
+    assert response.status_code == status.HTTP_201_CREATED
     response = asset_edit_client.post(
         "/api/assets/upsert/",
         json.dumps(
@@ -921,11 +932,11 @@ def test_upsert_no_mac_address_duplicate(asset_edit_client):
         ),
         content_type="application/json",
     )
-    assert response.status_code == 412  # Precondition failed
+    assert response.status_code == status.HTTP_412_PRECONDITION_FAILED
     assert models.Asset.objects.count() == 1
 
 
-def test_upsert_ipv6(asset_edit_client):
+def test_upsert_ipv6(asset_edit_client: APIClient) -> None:
     """Call upsert endpoint with an ipv6 address.
 
     There is no "ipv6_address" field on an Asset model.  The /api/upsert/
@@ -941,11 +952,11 @@ def test_upsert_ipv6(asset_edit_client):
         ),
         content_type="application/json",
     )
-    assert response.status_code == 201  # Created
+    assert response.status_code == status.HTTP_201_CREATED
     assert models.Asset.objects.count() == 1
 
 
-def test_upsert_many_fields(asset_edit_client):
+def test_upsert_many_fields(asset_edit_client: APIClient) -> None:
     """Call upsert endpoint with a fields typically provided by sniffer."""
     response = asset_edit_client.post(
         "/api/assets/upsert/",
@@ -964,11 +975,11 @@ def test_upsert_many_fields(asset_edit_client):
         ),
         content_type="application/json",
     )
-    assert response.status_code == 201  # Created
+    assert response.status_code == status.HTTP_201_CREATED
     assert models.Asset.objects.count() == 1
 
 
-def test_upsert_ipv4(asset_edit_client):
+def test_upsert_ipv4(asset_edit_client: APIClient) -> None:
     """Call upsert endpoint with a "ipv4_address" field.
 
     There is no "ipv4_address" field on an Asset model.  The /api/upsert/
@@ -984,13 +995,13 @@ def test_upsert_ipv4(asset_edit_client):
         ),
         content_type="application/json",
     )
-    assert response.status_code == 201  # Created
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.data["ip_address"] == "10.0.0.1"
     asset = models.Asset.objects.get()
     assert str(asset.ip_address) == "10.0.0.1"
 
 
-def test_upsert_bad_key(asset_edit_client):
+def test_upsert_bad_key(asset_edit_client: APIClient) -> None:
     """Call upsert endpoint with a bad key in the JSON."""
     with pytest.raises(django.core.exceptions.FieldDoesNotExist):
         _ = asset_edit_client.post(
@@ -1005,7 +1016,7 @@ def test_upsert_bad_key(asset_edit_client):
         )
 
 
-def test_upsert_open_port_tcp(asset_edit_client):
+def test_upsert_open_port_tcp(asset_edit_client: APIClient) -> None:
     """Call upsert endpoint with a "open_port_tcp" field.
 
     There is no "open_tcp_port" field on an Asset model.  The /api/upsert/
@@ -1021,13 +1032,13 @@ def test_upsert_open_port_tcp(asset_edit_client):
         ),
         content_type="application/json",
     )
-    assert response.status_code == 201  # Created
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.data["open_ports_tcp"] == [80]
     asset = models.Asset.objects.get()
     assert asset.open_ports_tcp == [80]
 
 
-def test_upsert_identifier(asset_edit_client):
+def test_upsert_identifier(asset_edit_client: APIClient) -> None:
     """Call upsert endpoint with a "identifier" field.
 
     Coerce "identifier" field to "name".
@@ -1042,14 +1053,14 @@ def test_upsert_identifier(asset_edit_client):
         ),
         content_type="application/json",
     )
-    assert response.status_code == 201  # Created
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.data["name"] == "Alaris 8100"
     asset = models.Asset.objects.get()
     assert asset.name == "Alaris 8100"
 
 
 @pytest.mark.parametrize(
-    "date_range, num_assets",
+    ("date_range", "num_assets"),
     [
         ("today", 1),  # Today
         ("yesterday", 2),  # Yesterday
@@ -1060,7 +1071,9 @@ def test_upsert_identifier(asset_edit_client):
         ("year", 7),  # This year
     ],
 )
-def test_asset_date_range(date_range, num_assets, auth_client):
+def test_asset_date_range(
+    date_range: str, num_assets: int, auth_client: APIClient
+) -> None:
     """Test that we can get assets from different date ranges.
 
     Using freezegun, creating assets today, yesterday, this week, etc.
@@ -1089,24 +1102,101 @@ def test_asset_date_range(date_range, num_assets, auth_client):
         models.Asset.objects.create(name="this_year")
 
     res = auth_client.get("/api/assets/")
-    assert res.status_code == 200
-    assert res.data["count"] == 7
+    assert res.status_code == status.HTTP_200_OK
+    total_assets = 7
+    assert res.data["count"] == total_assets
 
     with freeze_time("2018-06-30 13:00:00", tz_offset=0):
         res = auth_client.get(f"/api/assets/?date_range={date_range}")
         assert res.data["count"] == num_assets
 
 
-def test_external_key_non_connector(db, auth_client):
-    """Test that external_links/ detail route doesn't barf on non-connector
-    external key.
-    """
+def test_external_key_non_connector(auth_client: APIClient) -> None:
+    """Test that external_links/ detail route handles non-connector external keys."""
     foobar = models.Asset.objects.create(name="Foobar")
     foobar.external_keys = {"ECN": "12345"}
     foobar.save()
     assert foobar.external_keys["ECN"] == "12345"
 
     res = auth_client.get(f"/api/assets/{foobar.id}/external_links/")
-    assert res.status_code == 200
+    assert res.status_code == status.HTTP_200_OK
     assert len(res.data) == 1
-    assert res.data["ECN"] == "12345"
+
+
+# ---------------------------------------------------------------------------
+# Bulk PATCH tests
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_update_updates_fields(asset_edit_client: APIClient) -> None:
+    """PATCH /api/assets/bulk_update/ updates only the provided fields."""
+    a1 = models.Asset.objects.create(hostname="device-a", os="Windows")
+    a2 = models.Asset.objects.create(hostname="device-b", os="Linux")
+
+    response = asset_edit_client.patch(
+        "/api/assets/bulk_update/",
+        json.dumps([
+            {"id": a1.id, "hostname": "device-a-updated"},
+            {"id": a2.id, "os": "FreeBSD"},
+        ]),
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data) == 2  # noqa: PLR2004
+
+    a1.refresh_from_db()
+    a2.refresh_from_db()
+    assert a1.hostname == "device-a-updated"
+    assert a1.os == "Windows"  # untouched
+    assert a2.os == "FreeBSD"
+    assert a2.hostname == "device-b"  # untouched
+
+
+def test_bulk_update_unknown_id_returns_404(asset_edit_client: APIClient) -> None:
+    """PATCH /api/assets/bulk_update/ returns 404 if any id is not found."""
+    a1 = models.Asset.objects.create(hostname="device-a")
+    response = asset_edit_client.patch(
+        "/api/assets/bulk_update/",
+        json.dumps([
+            {"id": a1.id, "hostname": "updated"},
+            {"id": 99999, "hostname": "ghost"},
+        ]),
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_bulk_update_missing_id_returns_400(asset_edit_client: APIClient) -> None:
+    """PATCH /api/assets/bulk_update/ returns 400 if any item lacks an id."""
+    response = asset_edit_client.patch(
+        "/api/assets/bulk_update/",
+        json.dumps([{"hostname": "no-id-here"}]),
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_bulk_update_non_list_returns_400(asset_edit_client: APIClient) -> None:
+    """PATCH /api/assets/bulk_update/ returns 400 if body is not a list."""
+    response = asset_edit_client.patch(
+        "/api/assets/bulk_update/",
+        json.dumps({"id": 1, "hostname": "not-a-list"}),
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_bulk_update_idempotent(asset_edit_client: APIClient) -> None:
+    """Sending the same PATCH twice produces the same result."""
+    asset = models.Asset.objects.create(hostname="original")
+    payload = json.dumps([{"id": asset.id, "hostname": "updated"}])
+
+    r1 = asset_edit_client.patch(
+        "/api/assets/bulk_update/", payload, content_type="application/json"
+    )
+    r2 = asset_edit_client.patch(
+        "/api/assets/bulk_update/", payload, content_type="application/json"
+    )
+    assert r1.status_code == status.HTTP_200_OK
+    assert r2.status_code == status.HTTP_200_OK
+    assert r1.data[0]["hostname"] == r2.data[0]["hostname"] == "updated"

--- a/blueflow/tests/test_tapirx_upsert.py
+++ b/blueflow/tests/test_tapirx_upsert.py
@@ -107,9 +107,7 @@ def test_tapirx_upsert_token_auth(tapirx_token_client: APIClient) -> None:
 @pytest.mark.skip(reason="Blueflow uses AllowAny; auth enforced by consuming product")
 def test_tapirx_upsert_unauth_403(db: None, enable_core_switch: None) -> None:  # noqa: ARG001
     """POST unauthenticated would assert 403 if IsAuthenticated were enforced."""
-    from rest_framework.test import APIClient as _APIClient  # noqa: PLC0415
-
-    client = _APIClient()
+    client = APIClient()
     response = client.post(
         "/api/assets/upsert/",
         json.dumps(TAPIRX_FULL_PAYLOAD),
@@ -182,10 +180,8 @@ def test_get_asset_after_upsert_404(asset_edit_client: APIClient) -> None:
 @pytest.mark.skip(reason="Blueflow uses AllowAny; auth enforced by consuming product")
 def test_get_asset_after_upsert_unauth_403(db: None, enable_core_switch: None) -> None:  # noqa: ARG001
     """GET without auth would assert 403 if IsAuthenticated were enforced."""
-    from rest_framework.test import APIClient as _APIClient  # noqa: PLC0415
-
     asset = models.Asset.objects.create(mac_address="aa:bb:cc:dd:ee:ff")
-    client = _APIClient()
+    client = APIClient()
     response = client.get(f"/api/assets/{asset.id}/")
     assert response.status_code == status.HTTP_403_FORBIDDEN
 

--- a/blueflow/tests/test_tapirx_upsert.py
+++ b/blueflow/tests/test_tapirx_upsert.py
@@ -2,11 +2,19 @@
 
 Validates that Tapirx can POST to /api/assets/upsert/ and that assets
 are retrievable via GET /api/assets/{id}/.
+
+.. deprecated::
+    The /api/assets/upsert/ endpoint is deprecated. External tools should
+    use PATCH /api/assets/<id>/ for single updates or
+    PATCH /api/assets/bulk_update/ for batch updates.
+    These tests will be removed when the upsert endpoint is removed.
 """
 
 import json
 
 import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
 
 from blueflow import models
 
@@ -24,7 +32,7 @@ TAPIRX_FULL_PAYLOAD = {
 }
 
 
-def _post_upsert(client, payload):
+def _post_upsert(client: APIClient, payload: dict) -> object:
     """POST payload to upsert endpoint."""
     return client.post(
         "/api/assets/upsert/",
@@ -38,17 +46,17 @@ def _post_upsert(client, payload):
 # ---------------------------------------------------------------------------
 
 
-def test_tapirx_upsert_create(asset_edit_client):
+def test_tapirx_upsert_create(asset_edit_client: APIClient) -> None:
     """POST full Tapirx payload, assert 201, verify ip_address, name, open_ports_tcp."""
     response = _post_upsert(asset_edit_client, TAPIRX_FULL_PAYLOAD)
-    assert response.status_code == 201
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.data["ip_address"] == "10.0.0.155"
     assert response.data["name"] == "Infuse-O-Matic Peach B+"
     assert response.data["open_ports_tcp"] == [2575]
     assert models.Asset.objects.count() == 1
 
 
-def test_tapirx_upsert_update(asset_edit_client):
+def test_tapirx_upsert_update(asset_edit_client: APIClient) -> None:
     """POST twice same MAC, assert 200 on second, verify field update."""
     payload1 = {
         "mac_address": "11:22:33:44:55:66",
@@ -56,7 +64,7 @@ def test_tapirx_upsert_update(asset_edit_client):
         "identifier": "Original Name",
     }
     response1 = _post_upsert(asset_edit_client, payload1)
-    assert response1.status_code == 201
+    assert response1.status_code == status.HTTP_201_CREATED
 
     payload2 = {
         "mac_address": "11:22:33:44:55:66",
@@ -64,54 +72,54 @@ def test_tapirx_upsert_update(asset_edit_client):
         "identifier": "Updated Name",
     }
     response2 = _post_upsert(asset_edit_client, payload2)
-    assert response2.status_code == 200
+    assert response2.status_code == status.HTTP_200_OK
     assert response2.data["ip_address"] == "10.0.0.2"
     assert response2.data["name"] == "Updated Name"
     assert models.Asset.objects.count() == 1
 
 
-def test_tapirx_upsert_minimal(asset_edit_client):
+def test_tapirx_upsert_minimal(asset_edit_client: APIClient) -> None:
     """POST only mac_address, assert 201."""
     response = _post_upsert(asset_edit_client, {"mac_address": "00:03:b1:b5:b6:48"})
-    assert response.status_code == 201
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.data["mac_address"] == "00:03:b1:b5:b6:48"
     assert models.Asset.objects.count() == 1
 
 
-def test_tapirx_upsert_no_mac_412(asset_edit_client):
+def test_tapirx_upsert_no_mac_412(asset_edit_client: APIClient) -> None:
     """POST without mac_address, assert 412."""
     response = _post_upsert(
         asset_edit_client,
         {"ipv4_address": "10.0.0.1", "identifier": "No MAC"},
     )
-    assert response.status_code == 412
+    assert response.status_code == status.HTTP_412_PRECONDITION_FAILED
     assert models.Asset.objects.count() == 0
 
 
-def test_tapirx_upsert_token_auth(tapirx_token_client):
+def test_tapirx_upsert_token_auth(tapirx_token_client: APIClient) -> None:
     """POST with tapirx_token_client (Token header), assert 201."""
     response = _post_upsert(tapirx_token_client, TAPIRX_FULL_PAYLOAD)
-    assert response.status_code == 201
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.data["mac_address"] == "00:03:b1:b5:b6:48"
     assert models.Asset.objects.count() == 1
 
 
 @pytest.mark.skip(reason="Blueflow uses AllowAny; auth enforced by consuming product")
-def test_tapirx_upsert_unauth_403(db, enable_core_switch):
+def test_tapirx_upsert_unauth_403(db: None, enable_core_switch: None) -> None:  # noqa: ARG001
     """POST unauthenticated would assert 403 if IsAuthenticated were enforced."""
-    from rest_framework.test import APIClient
+    from rest_framework.test import APIClient as _APIClient  # noqa: PLC0415
 
-    client = APIClient()
+    client = _APIClient()
     response = client.post(
         "/api/assets/upsert/",
         json.dumps(TAPIRX_FULL_PAYLOAD),
         content_type="application/json",
     )
-    assert response.status_code == 403
+    assert response.status_code == status.HTTP_403_FORBIDDEN
     assert models.Asset.objects.count() == 0
 
 
-def test_tapirx_upsert_ignored_fields(asset_edit_client):
+def test_tapirx_upsert_ignored_fields(asset_edit_client: APIClient) -> None:
     """connect_port_tcp and ipv6_address are silently dropped."""
     payload = {
         "mac_address": "11:22:33:44:55:66",
@@ -119,21 +127,21 @@ def test_tapirx_upsert_ignored_fields(asset_edit_client):
         "connect_port_tcp": "9999",
     }
     response = _post_upsert(asset_edit_client, payload)
-    assert response.status_code == 201
+    assert response.status_code == status.HTTP_201_CREATED
     asset = models.Asset.objects.get()
     assert asset.mac_address == "11:22:33:44:55:66"
     assert not hasattr(asset, "ipv6_address") or asset.ipv6_address is None
     assert not hasattr(asset, "connect_port_tcp")
 
 
-def test_tapirx_upsert_open_port_appends(asset_edit_client):
+def test_tapirx_upsert_open_port_appends(asset_edit_client: APIClient) -> None:
     """POST twice with different open_port_tcp, verify both in open_ports_tcp."""
     payload1 = {
         "mac_address": "11:22:33:44:55:66",
         "open_port_tcp": "80",
     }
     response1 = _post_upsert(asset_edit_client, payload1)
-    assert response1.status_code == 201
+    assert response1.status_code == status.HTTP_201_CREATED
     assert response1.data["open_ports_tcp"] == [80]
 
     payload2 = {
@@ -141,7 +149,7 @@ def test_tapirx_upsert_open_port_appends(asset_edit_client):
         "open_port_tcp": "443",
     }
     response2 = _post_upsert(asset_edit_client, payload2)
-    assert response2.status_code == 200
+    assert response2.status_code == status.HTTP_200_OK
     assert set(response2.data["open_ports_tcp"]) == {80, 443}
     asset = models.Asset.objects.get()
     assert set(asset.open_ports_tcp) == {80, 443}
@@ -152,34 +160,34 @@ def test_tapirx_upsert_open_port_appends(asset_edit_client):
 # ---------------------------------------------------------------------------
 
 
-def test_get_asset_by_id_after_upsert(asset_edit_client):
+def test_get_asset_by_id_after_upsert(asset_edit_client: APIClient) -> None:
     """POST upsert, extract id, GET /api/assets/{id}/, assert 200 and fields match."""
     response = _post_upsert(asset_edit_client, TAPIRX_FULL_PAYLOAD)
-    assert response.status_code == 201
+    assert response.status_code == status.HTTP_201_CREATED
     asset_id = response.data["id"]
     get_response = asset_edit_client.get(f"/api/assets/{asset_id}/")
-    assert get_response.status_code == 200
+    assert get_response.status_code == status.HTTP_200_OK
     assert get_response.data["id"] == asset_id
     assert get_response.data["ip_address"] == "10.0.0.155"
     assert get_response.data["name"] == "Infuse-O-Matic Peach B+"
     assert get_response.data["mac_address"] == "00:03:b1:b5:b6:48"
 
 
-def test_get_asset_after_upsert_404(asset_edit_client):
+def test_get_asset_after_upsert_404(asset_edit_client: APIClient) -> None:
     """GET /api/assets/99999/, assert 404."""
     response = asset_edit_client.get("/api/assets/99999/")
-    assert response.status_code == 404
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.skip(reason="Blueflow uses AllowAny; auth enforced by consuming product")
-def test_get_asset_after_upsert_unauth_403(db, enable_core_switch):
+def test_get_asset_after_upsert_unauth_403(db: None, enable_core_switch: None) -> None:  # noqa: ARG001
     """GET without auth would assert 403 if IsAuthenticated were enforced."""
-    from rest_framework.test import APIClient
+    from rest_framework.test import APIClient as _APIClient  # noqa: PLC0415
 
     asset = models.Asset.objects.create(mac_address="aa:bb:cc:dd:ee:ff")
-    client = APIClient()
+    client = _APIClient()
     response = client.get(f"/api/assets/{asset.id}/")
-    assert response.status_code == 403
+    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 # ---------------------------------------------------------------------------
@@ -187,12 +195,12 @@ def test_get_asset_after_upsert_unauth_403(db, enable_core_switch):
 # ---------------------------------------------------------------------------
 
 
-def test_upsert_then_list(asset_edit_client):
+def test_upsert_then_list(asset_edit_client: APIClient) -> None:
     """POST upsert, GET /api/assets/, assert count=1 and asset in results."""
     response = _post_upsert(asset_edit_client, TAPIRX_FULL_PAYLOAD)
-    assert response.status_code == 201
+    assert response.status_code == status.HTTP_201_CREATED
     list_response = asset_edit_client.get("/api/assets/")
-    assert list_response.status_code == 200
+    assert list_response.status_code == status.HTTP_200_OK
     assert list_response.data["count"] == 1
     results = list_response.data["results"]
     assert len(results) == 1
@@ -202,10 +210,10 @@ def test_upsert_then_list(asset_edit_client):
 @pytest.mark.skip(
     reason="django-simple-history update_change_reason filter fails with netfields"
 )
-def test_upsert_history_reason(asset_edit_client):
+def test_upsert_history_reason(asset_edit_client: APIClient) -> None:
     """POST upsert with provenance/client_id/last_seen, assert history_change_reason."""
     response = _post_upsert(asset_edit_client, TAPIRX_FULL_PAYLOAD)
-    assert response.status_code == 201
+    assert response.status_code == status.HTTP_201_CREATED
     asset = models.Asset.objects.get()
     latest = asset.history.order_by("-history_date").first()
     assert latest is not None
@@ -216,13 +224,13 @@ def test_upsert_history_reason(asset_edit_client):
     assert "2019-01-02" in reason
 
 
-def test_upsert_nic_vendor_from_mac(asset_edit_client):
+def test_upsert_nic_vendor_from_mac(asset_edit_client: APIClient) -> None:
     """POST with registered OUI MAC, assert nic_vendor auto-populated from netaddr."""
     response = _post_upsert(
         asset_edit_client,
         {"mac_address": "00:03:b1:b5:b6:48", "identifier": "Medical device"},
     )
-    assert response.status_code == 201
+    assert response.status_code == status.HTTP_201_CREATED
     # OUI 00:03:b1 is registered; vendor may be Hospira, ICU Medical, etc.
     assert response.data["nic_vendor"] is not None
     assert len(response.data["nic_vendor"]) > 0

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -1022,9 +1022,22 @@ class AssetViewSet(
             **request.data,
             defaults=request.data,
         )
-        hist_utils.update_change_reason(
-            asset, f"{provenance} seen by {client_id} at {last_seen}"
-        )
+        # Ported from experimental/testbed-build:bf_opencore/views/asset.py.
+        # update_change_reason can fail when its filter returns None (e.g.
+        # with netfields/ArrayField); fall back to updating the latest record.
+        reason = f"{provenance} seen by {client_id} at {last_seen}"
+        try:
+            hist_utils.update_change_reason(asset, reason)
+        except AttributeError:
+            record = asset.history.order_by("-history_date").first()
+            if record is not None:
+                record.__class__.objects.filter(pk=record.pk).update(
+                    history_change_reason=reason
+                )
+            else:
+                logger.debug(
+                    "Could not set history_change_reason for asset pk=%s", asset.pk
+                )
 
         # Add port to list of open ports
         if open_port_tcp:

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -9,6 +9,7 @@ import django_filters
 import django_filters.rest_framework.filters as drf_filters
 import netfields
 from django.core import exceptions as d_ex
+from django.db import transaction
 from django.db.models import Case, Count, QuerySet, When
 from django.db.models.aggregates import Func
 from django.db.utils import IntegrityError
@@ -929,7 +930,8 @@ class AssetViewSet(
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        results = []
+        # Phase 1: normalise and validate every item before touching the DB.
+        validated: list[tuple[Asset, AssetSerializer]] = []
         for item in request.data:
             asset_id = item.get("id")
             if asset_id is None:
@@ -937,6 +939,14 @@ class AssetViewSet(
                     {"detail": "Each item must include an 'id' field."},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
+
+            # Apply the same field normalisations as create/update.
+            if "open_ports_tcp" in item:
+                item["open_ports_tcp"] = self._ports_string_to_list(item["open_ports_tcp"])
+            if item.get("mac_address") == "":
+                logger.debug("Coercing empty string MAC to None")
+                item["mac_address"] = None
+
             try:
                 asset = Asset.objects.get(pk=asset_id)
             except Asset.DoesNotExist:
@@ -948,10 +958,16 @@ class AssetViewSet(
                 asset, data=item, partial=True, context={"request": request}
             )
             serializer.is_valid(raise_exception=True)
-            serializer.save()
-            results.append(serializer.data)
+            validated.append((asset, serializer))
 
-        return Response(results, status=status.HTTP_200_OK)
+        # Phase 2: commit all updates atomically — all succeed or none do.
+        with transaction.atomic():
+            results = [serializer.save() for _asset, serializer in validated]
+
+        return Response(
+            AssetSerializer(results, many=True, context={"request": request}).data,
+            status=status.HTTP_200_OK,
+        )
 
     @action(detail=False, methods=["POST"])
     def upsert(self, request: Request) -> Response:

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -3,17 +3,19 @@
 import importlib
 import logging
 import re
+from typing import ClassVar
 
 import django_filters
 import django_filters.rest_framework.filters as drf_filters
 import netfields
 from django.core import exceptions as d_ex
-from django.db.models import Case, Count, Exists, OuterRef, Sum, When
+from django.db.models import Case, Count, QuerySet, When
 from django.db.models.aggregates import Func
 from django.db.utils import IntegrityError
 from django.utils import timezone
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework_csv import renderers as drf_csv_renderers
@@ -49,7 +51,7 @@ class JSONChild(Func):
     template = "%(expressions)s%(function)s'{%(path)s}'"
     arity = 1
 
-    def __init__(self, expression, path):
+    def __init__(self, expression: str, path: str) -> None:
         """Form an expression and plug the path argument into the template."""
         super().__init__(expression, path=path)
 
@@ -66,6 +68,8 @@ class MiniAssetVulnerabilitySerializer(serializers.HyperlinkedModelSerializer):
     )
 
     class Meta:
+        """Wire this serializer to a model."""
+
         model = AssetVulnerability
         fields = (
             "id",
@@ -107,7 +111,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
         model = Asset
 
         # Fields defined in the schema
-        asset_fields = tuple(f.name for f in model._meta.fields)
+        asset_fields = tuple(f.name for f in model._meta.fields)  # noqa: SLF001
 
         # Fields that are computed (not stored directly in schema)
         computed_fields = (
@@ -124,9 +128,9 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
         fields = asset_fields + computed_fields
 
-        read_only_fields = ["nic_vendor"]
+        read_only_fields: ClassVar = ["nic_vendor"]
 
-    def validate_ip_address(self, ip_string):
+    def validate_ip_address(self, ip_string: str) -> str | None:
         """If the IP address is empty, we coerce it to None.
 
         This happens anyway, when it gets stored in the database --
@@ -137,7 +141,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
             return None
         return ip_string
 
-    def validate_mac_address(self, mac_string):
+    def validate_mac_address(self, mac_string: str) -> str | None:
         """If the MAC address is empty, we coerce it to None.
 
         This happens anyway, when it gets stored in the database --
@@ -151,7 +155,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
             return None
         return mac_string
 
-    def validate_open_ports_tcp(self, ports_list):
+    def validate_open_ports_tcp(self, ports_list: list) -> list:
         """Ensure that TCP ports are in the correct range.
 
         NOTE: For UDP, '0' is in fact an acceptable port... but not for TCP.
@@ -161,8 +165,10 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
         # Ideally, this should have been solved with a CHECK CONSTRAINT
         # at the database level, then we wouldn't have needed a
         # validator here.
-        if not all(1 <= port <= 65535 for port in ports_list):
-            raise serializers.ValidationError("TCP Ports must be in range 1--65535")
+        max_port = 65535
+        if not all(1 <= port <= max_port for port in ports_list):
+            _msg = "TCP Ports must be in range 1--65535"
+            raise serializers.ValidationError(_msg)
         return sorted(set(ports_list))
 
 
@@ -201,7 +207,8 @@ class ChangeLogMetaclass(type(AssetSerializer)):
     type(AssetSerializer) ("what is the metaclass for AssetSerializer").
     """
 
-    def __new__(mcs, name, parents, dct):
+    def __new__(mcs, name: str, parents: tuple, dct: dict) -> "ChangeLogMetaclass":
+        """Create the ChangeLogAssetSerializer class."""
         if "Meta" in dct:
             # NOTE: the changed fields are supposed to be the same as in
             #   AssetSerializer.Meta.asset_fields -- except for 'id'
@@ -236,6 +243,8 @@ class ChangeLogAssetSerializer(
     )
 
     class Meta:
+        """Wire this serializer to a model."""
+
         model = Asset.history.model
         changed_fields = AssetSerializer.Meta.asset_fields
         fields = changed_fields + HistoricalAssetSerializer.Meta.historical_fields
@@ -259,15 +268,19 @@ class AssetFilter(django_filters.rest_framework.FilterSet):
     pulse = django_filters.NumberFilter(method="filter_pulse")
 
     @staticmethod
-    def filter_network(queryset, name, value):
+    def filter_network(queryset: QuerySet, name: str, value: int) -> QuerySet:
         """Get assets that belong to a certain network."""
-        assert name == "network"
+        if name != "network":
+            _msg = f"Unexpected filter name: {name!r}"
+            raise ValueError(_msg)
         return queryset.in_network(network_id=value)
 
     @staticmethod
-    def filter_no_network(queryset, name, value):
+    def filter_no_network(queryset: QuerySet, name: str, value: bool) -> QuerySet:  # noqa: FBT001
         """Get assets that belong to no network."""
-        assert name == "no_network"
+        if name != "no_network":
+            _msg = f"Unexpected filter name: {name!r}"
+            raise ValueError(_msg)
         if value is not True:
             # This is sliiightly iffy.  The user might expect to see the
             # assets that *do* belong to a network.  Oh well.
@@ -275,7 +288,7 @@ class AssetFilter(django_filters.rest_framework.FilterSet):
         return queryset.no_network()
 
     @staticmethod
-    def filter_pulse(queryset, name, value):
+    def filter_pulse(_queryset: QuerySet, _name: str, value: int) -> QuerySet:
         """Get assets pertinent to a specific Pulse feed item."""
         try:
             pulse = PulseFeedItem.objects.get(external_pulse_id=value)
@@ -285,9 +298,13 @@ class AssetFilter(django_filters.rest_framework.FilterSet):
         return pulse.asset_qset()
 
     @staticmethod
-    def filter_active_vulnerability(queryset, name, value):
+    def filter_active_vulnerability(
+        queryset: QuerySet, name: str, value: int
+    ) -> QuerySet:
         """Get assets with a vulnerability open."""
-        assert name == "active_vulnerability"
+        if name != "active_vulnerability":
+            _msg = f"Unexpected filter name: {name!r}"
+            raise ValueError(_msg)
         return queryset.filter(
             asset_vulnerabilities__vulnerability=value,
             asset_vulnerabilities__date_remediated__isnull=True,
@@ -295,17 +312,17 @@ class AssetFilter(django_filters.rest_framework.FilterSet):
         )
 
     @staticmethod
-    def filter_unassessed(queryset, name, value):
+    def filter_unassessed(queryset: QuerySet, _name: str, _value: bool) -> QuerySet:  # noqa: FBT001
         """Get assets that lack AssetRiskFactors.
 
         Calling with value False is a silly double negative ("not unassessed").
         """
-        # TODO: Implement unassessed after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Unassessed is not implemented")
-        return queryset.filter(asset_risk_factors__isnull=value).distinct()
+        # TODO: Implement unassessed  # noqa: TD002,TD003,FIX002
+        _msg = "Unassessed is not implemented"
+        raise NotImplementedError(_msg)
 
     @staticmethod
-    def filter_assessed_factor(queryset, name, value):
+    def filter_assessed_factor(queryset: QuerySet, _name: str, value: int) -> QuerySet:
         """Get assets that have or lack a *particular* RiskFactor.
 
         To find assets that *have* a particular RiskFactor n, query with
@@ -314,32 +331,13 @@ class AssetFilter(django_filters.rest_framework.FilterSet):
         To find assets that *lack* a particular RiskFactor n, query with
         assessed_factor=-n.
         """
-        # TODO: Implement assessed_factor after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Assessed factor is not implemented")
-
-        invert = False
-        if value < 0:
-            invert = True
-            value = abs(value)
-
-        try:
-            rf = RiskFactor.objects.get(pk=value)
-        except RiskFactor.DoesNotExist:
-            return Asset.objects.none()
-
-        # subquery: for each asset, whether or not it has this RiskFactor
-        has_this_rf = AssetRiskFactor.objects.filter(
-            asset_id=OuterRef("pk"),
-            risk_factor=rf,
-        )
-
-        # filter the queryset: 'not invert' means filter for *has this RF*,
-        # 'invert' means filter for *does not have this RF*
-        return queryset.annotate(
-            has_rf=Exists(has_this_rf),
-        ).filter(has_rf=not invert)
+        # TODO: Implement assessed_factor  # noqa: TD002,TD003,FIX002
+        _msg = "Assessed factor is not implemented"
+        raise NotImplementedError(_msg)
 
     class Meta:
+        """Wire this filter to a model."""
+
         model = Asset
 
         # The first lookup in each field will be used as the default by
@@ -347,17 +345,11 @@ class AssetFilter(django_filters.rest_framework.FilterSet):
         #
         # Documentation about lookups is here:
         # https://docs.djangoproject.com/en/1.11/ref/models/querysets/#field-lookups
-        fields = {
+        fields = {  # noqa: RUF012
             "hostname": ["icontains"],
             "nic_vendor": ["icontains"],
             "category": ["icontains", "exact"],
-            # TODO: Add risk score filters back in once we have a generalized algorithm
-            # 'risk_score': ['gte', 'gt', 'lt', 'lte'],
-            # 'risk_score_cli': ['gte', 'gt', 'lt', 'lte'],
-            # 'risk_score_sec': ['gte', 'gt', 'lt', 'lte'],
-            # 'risk_score_pri': ['gte', 'gt', 'lt', 'lte'],
-            # 'risk_score_impact': ['gte', 'gt', 'lt', 'lte'],
-            # 'risk_score_likelihood': ['gte', 'gt', 'lt', 'lte'],
+            # TODO: Add risk score filters  # noqa: TD002,TD003,FIX002
             "id": ["in"],
             "ip_address": [
                 "istartswith",
@@ -394,10 +386,9 @@ class AssetFilter(django_filters.rest_framework.FilterSet):
             "asset_custom_fields__value_text": ["istartswith"],
             "asset_vulnerabilities__date_remediated": ["isnull"],
             "asset_vulnerabilities__date_ignored": ["isnull"],
-            # TODO: Add asset_risk_factors filters back in once we have a generalized algorithm
-            # 'asset_risk_factors': ['isnull'],
+            # TODO: Add asset_risk_factors filters  # noqa: TD002,TD003,FIX002
         }
-        filter_overrides = {
+        filter_overrides = {  # noqa: RUF012
             netfields.InetAddressField: {
                 "filter_class": django_filters.Filter,
             },
@@ -428,12 +419,13 @@ class AssetViewSet(
     list: Return a list of assets.
 
     Additional methods:
+    `/bulk_update` — PATCH a list of assets by id (partial updates)
     `/duplicate_ips`
     `/histogram`
     `/risk_per_manufacturer`
     `/riskiest`
     `/summary`
-    `/upsert`
+    `/upsert` — DEPRECATED: use PATCH /api/assets/<id>/ or /bulk_update/
 
     In addition, there are several filtering and search terms available.
 
@@ -445,7 +437,8 @@ class AssetViewSet(
 
     waffle_switch = "core"
 
-    renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES) + (
+    renderer_classes = (
+        *api_settings.DEFAULT_RENDERER_CLASSES,
         drf_csv_renderers.PaginatedCSVRenderer,
     )
 
@@ -487,7 +480,7 @@ class AssetViewSet(
     )
     filterset_class = AssetFilter
 
-    def get_renderer_context(self):
+    def get_renderer_context(self) -> dict:
         """If caller specifies fields, then set the CSV header accordingly.
 
         If not, use a default set.
@@ -509,11 +502,7 @@ class AssetViewSet(
             "tag_number",
             "category",
             "date_added",
-            # TODO: Add risk score filters back in once we have a generalized algorithm
-            # 'risk_score',
-            # 'risk_score_sec',
-            # 'risk_score_pri',
-            # 'risk_score_cli',
+            # TODO: Add risk score filters  # noqa: TD002,TD003,FIX002
             "udi",
         ]
         context = super().get_renderer_context()
@@ -524,7 +513,7 @@ class AssetViewSet(
         return context
 
     @staticmethod
-    def _ports_string_to_list(ports_string):
+    def _ports_string_to_list(ports_string: str | None) -> list:
         """Convert string of integers to a sorted list of unique integers.
 
         Separator(s) can be one of: space, comma, semicolon, pipe, or newline,
@@ -544,7 +533,7 @@ class AssetViewSet(
 
         return ports_list
 
-    def _validate_open_ports(self, request):
+    def _validate_open_ports(self, request: Request) -> None:
         """Convert TCP port string to list.
 
         Modifies the 'request' in-place.
@@ -555,7 +544,7 @@ class AssetViewSet(
             )
 
     @staticmethod
-    def _validate_mac_address(request):
+    def _validate_mac_address(request: Request) -> None:
         """Convert an empty string MAC address to None.
 
         This would happen at a later point, but doing it explicitly here
@@ -568,34 +557,30 @@ class AssetViewSet(
             logger.debug("Coercing empty string MAC to None")
             request.data["mac_address"] = None
 
-    def update(self, request, *args, **kwargs):
+    def update(self, request: Request, *args: int, **kwargs: str) -> Response:
         """Override update in order to convert TCP port string to list.
 
         NOTE: We can't use a "serializer validator" for this, since the
         validator would kick a string out (it really wants a list.)
         """
-        # import pdb; pdb.set_trace()
         self._validate_open_ports(request)
         self._validate_mac_address(request)
-        r = super().update(request, *args, **kwargs)
-        return r
+        return super().update(request, *args, **kwargs)
 
-    def create(self, request, *args, **kwargs):
+    def create(self, request: Request, *args: int, **kwargs: str) -> Response:
         """Override create in order to convert TCP port string to list.
 
         NOTE: (see 'update' method)
         """
-        # import pdb; pdb.set_trace()
         self._validate_open_ports(request)
         self._validate_mac_address(request)
-        r = super().create(request, *args, **kwargs)
-        return r
+        return super().create(request, *args, **kwargs)
 
     ################################
     # Detail methods/actions
 
     @action(detail=True)
-    def changelog(self, request, pk):
+    def changelog(self, request: Request, _pk: int) -> Response:
         """Like full history but fields are null except the one that changed.
 
         NOTE: not paginated, while the history is.
@@ -613,27 +598,13 @@ class AssetViewSet(
         return Response(serializer.data)
 
     @action(detail=True)
-    def external_links(self, request, pk):
+    def external_links(self, _request: Request, _pk: int) -> Response:
         """Return a dictionary of (systemname, url) external links."""
-        raise NotImplementedError("Connectors have been removed")
-        external_keys = self.get_object().external_keys
-        if not external_keys:
-            return Response({})
-
-        response = {}
-
-        # process connector-related external keys
-        for ek, key in external_keys.items():
-            try:
-                connector = Connector.objects.get(id=ek)
-                response[connector.display_name] = connector.url_for_asset(key)
-            except Connector.DoesNotExist:
-                response[ek] = key
-
-        return Response(response)
+        _msg = "Connectors have been removed"
+        raise NotImplementedError(_msg)
 
     @action(detail=True)
-    def fields(self, request, pk):
+    def fields(self, request: Request, pk: int) -> Response:
         """List fields for an Asset.
 
         Technically all assets will have the same fields.  But there's
@@ -652,7 +623,7 @@ class AssetViewSet(
         include_relations = relations.lower()[:1] in ["", "1", "t"]
 
         fields = []
-        for f in Asset._meta.get_fields():
+        for f in Asset._meta.get_fields():  # noqa: SLF001
             if f.is_relation and not include_relations:
                 continue
             if hasattr(f, "deconstruct"):
@@ -698,7 +669,7 @@ class AssetViewSet(
         )
 
     @action(detail=True)
-    def history(self, request, pk):
+    def history(self, request: Request, _pk: int) -> Response:
         """Full history of asset (paginated).
 
         Or, if a `field=<field_name>` query argument is given, returns
@@ -714,23 +685,25 @@ class AssetViewSet(
         if field_name is None:
             raise serializers.ValidationError(
                 {
-                    "field": f"User supplied query parameters '{request.query_params}' that did "
-                    "not include a field value"
+                    "field": (
+                        f"User supplied query parameters '{request.query_params}'"
+                        " that did not include a field value"
+                    )
                 }
             )
         try:
             rqset = self.get_object().field_history_rqset(field_name, newest_first=True)
-        except d_ex.FieldDoesNotExist:
+        except d_ex.FieldDoesNotExist as err:
             raise serializers.ValidationError(
                 {"field": f"User tried to query for nonexistent field '{field_name}'"}
-            )
+            ) from err
         serializer = HistoricalAssetSerializer(
             rqset, many=True, context={"request": request}
         )
         return Response(serializer.data)
 
     @action(detail=True)
-    def needs_sw_update(self, request, pk):
+    def needs_sw_update(self, _request: Request, _pk: int) -> Response:
         """Return whether this asset needs a software update.
 
         @returns:
@@ -748,7 +721,7 @@ class AssetViewSet(
         return Response(resp)
 
     @action(detail=True)
-    def networks(self, request, pk):
+    def networks(self, request: Request, _pk: int) -> Response:
         """Networks that this asset belongs to."""
         # FUTURE: Replace with /api/networks/?asset=<pk>
 
@@ -756,7 +729,7 @@ class AssetViewSet(
         return self.paginate_relations(request, qset, "NetworkSerializer")
 
     @action(detail=True)
-    def scans(self, request, pk):
+    def scans(self, request: Request, _pk: int) -> Response:
         """Return scans of the asset."""
         # FUTURE: Replace with /api/scans/?asset=<pk>
 
@@ -764,7 +737,7 @@ class AssetViewSet(
         return self.paginate_relations(request, scan_qset, "ScanSerializer")
 
     @action(detail=True)
-    def similar(self, request, pk):
+    def similar(self, request: Request, _pk: int) -> Response:
         """Similar assets."""
         exclude_self = True
         if request.query_params.get("exclude_self") in ("false", "0"):
@@ -773,12 +746,11 @@ class AssetViewSet(
         # This stuff might not be necessary.  The DRF pagination system
         # might take care of it (since it's the same serializer etc.
         qset = self.get_object().similar_qset(exclude_self=exclude_self)
-        # TODO: Add risk score ordering back in once we have a generalized algorithm
-        # .order_by('-risk_score'))
+        # TODO: Add risk score ordering  # noqa: TD002,TD003,FIX002
         return self.paginate_relations(request, qset, "AssetSerializer")
 
     @action(detail=True, methods=["GET", "POST"])
-    def tags(self, request, pk):
+    def tags(self, request: Request, _pk: int) -> Response | None:
         """Tags attached to the asset."""
         asset = self.get_object()
         if request.method == "GET":
@@ -795,12 +767,12 @@ class AssetViewSet(
                 )
             try:
                 tag = Tag.objects.get(pk=tag_id)
-            except d_ex.ObjectDoesNotExist:
+            except d_ex.ObjectDoesNotExist as err:
                 raise serializers.ValidationError(
                     {
                         "tag_id": [f"Tag does not exist: id={tag_id}"],
                     }
-                )
+                ) from err
             asset_tag = AssetTag(asset=asset, tag=tag, provenance="API")
             try:
                 asset_tag.save()
@@ -830,7 +802,7 @@ class AssetViewSet(
     # List methods/actions
 
     @action(detail=False)
-    def duplicate_ips(self, request):
+    def duplicate_ips(self, _request: Request) -> Response:
         """Return set of duplicate IP addresses and their counts."""
         assets = self.filter_queryset(self.get_queryset())
         qset = (
@@ -843,7 +815,7 @@ class AssetViewSet(
         return Response(resp)
 
     @action(detail=False)
-    def histogram(self, request):
+    def histogram(self, request: Request) -> Response:
         """Return an optionally filtered histogram over an asset field.
 
         Returns a list of {field_name: xxx, count: N} objects.
@@ -854,8 +826,8 @@ class AssetViewSet(
 
         try:
             limit = int(request.query_params.get("limit", 0))
-        except ValueError:
-            raise serializers.ValidationError({"limit": "Invalid limit"})
+        except ValueError as err:
+            raise serializers.ValidationError({"limit": "Invalid limit"}) from err
 
         include_null = request.query_params.get("nulls", "").lower() in (
             "true",
@@ -880,17 +852,17 @@ class AssetViewSet(
                 assets = assets.exclude(**params)
                 results = assets.values(field_name).annotate(count=Count(field_name))
 
-        except d_ex.FieldError:
+        except d_ex.FieldError as err:
             raise serializers.ValidationError(
                 {"field": f"Invalid field name '{field_name}'"}
-            )
+            ) from err
         results = results.order_by("-count")
         if limit > 0:
             results = results[:limit]
         return Response(results)
 
     @action(detail=False)
-    def risk_per_manufacturer(self, request):
+    def risk_per_manufacturer(self, request: Request) -> Response:
         """Calculate risk per manufacturer.
 
         Sort into one bin per manufacturer, sum the risks in each bin,
@@ -915,83 +887,80 @@ class AssetViewSet(
              GROUP BY "blueflow_asset"."manufacturer"
              ORDER BY "risk_score" DESC
         """
-        # TODO: Implement risk per manufacturer after we have a generalized algorithm
-        raise NotImplementedError("Risk per manufacturer is not implemented")
-
-        limit = int(request.query_params.get("limit", 0))
-
-        assets = self.filter_queryset(self.get_queryset())
-        qset = (
-            assets.exclude(manufacturer__isnull=True)
-            .exclude(risk_score__isnull=True)
-            .values("manufacturer")
-            .annotate(count=Count("manufacturer"), risk_score=Sum("risk_score") * 10.0)
-            .order_by("-risk_score")
-        )
-
-        risk_per_manufacturer = []
-        others = {"manufacturer": "others", "risk_score": 0, "count": 0}
-        for i, result in enumerate(qset):
-            if not limit or i < limit:
-                risk_per_manufacturer.append(result)
-            else:
-                others["count"] += result["count"]
-                try:
-                    others["risk_score"] += result["risk_score"]
-                except TypeError as err:
-                    assert result["risk_score"] is None, f"Unexpected error: '{err}'"
-                    logger.debug(
-                        "Manufacturer '%s' (count: %d) has no risk",
-                        result["manufacturer"],
-                        result["count"],
-                    )
-        response = Response(
-            {"risk_per_manufacturer": risk_per_manufacturer, "others": others}
-        )
-
-        return response
+        # TODO: Implement risk per manufacturer  # noqa: TD002,TD003,FIX002
+        _msg = "Risk per manufacturer is not implemented"
+        raise NotImplementedError(_msg)
 
     @action(detail=False)
-    def riskiest(self, request):
+    def riskiest(self, request: Request) -> Response:
         """Produce a paginated list of the "riskiest" assets."""
-        # TODO: Implement riskiest after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Riskiest is not implemented")
-        ordering = request.query_params.get("ordering")
-        if not ordering:
-            # None or empty string
-            ordering = "-risk_score"
-        qset = Asset.objects.filter(risk_score__isnull=False)
-
-        # add non-null constraints to other ordering fields provided
-        for fld in ordering.split(","):
-            o_fld = fld.lstrip("-")
-            if o_fld in ("risk_score_sec", "risk_score_pri", "risk_score_cli"):
-                qset = qset.filter(**{f"{o_fld}__isnull": False})
-
-        qset = qset.order_by(ordering)
-        return self.paginate_relations(request, qset, "AssetSerializer")
+        # TODO: Implement riskiest  # noqa: TD002,TD003,FIX002
+        _msg = "Riskiest is not implemented"
+        raise NotImplementedError(_msg)
 
     @action(detail=False)
-    def summary(self, request):
+    def summary(self, _request: Request) -> Response:
         """Return summary about an asset queryset."""
-        # TODO: Implement summary after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Summary is not implemented")
+        # TODO: Implement summary  # noqa: TD002,TD003,FIX002
+        _msg = "Summary is not implemented"
+        raise NotImplementedError(_msg)
 
-        assets = self.filter_queryset(self.get_queryset())
+    @action(detail=False, methods=["PATCH"])
+    def bulk_update(self, request: Request) -> Response:
+        """Perform partial updates on multiple assets in a single request.
 
-        return Response(
-            dict(
-                count=assets.count(),
-                identified_statistics=assets.identified_statistics(),
-                risk_statistics=assets.risk_statistics(),
-                risk_factor_statistics=assets.risk_factor_statistics(),
-                risk_histogram=assets.risk_histogram(),
+        Accepts a list of partial asset payloads. Each item must include an
+        ``id`` field identifying the asset to update. Only the fields provided
+        are modified; all other fields are left unchanged.
+
+        Returns a list of updated asset objects. If any ``id`` is not found a
+        404 response is returned immediately.
+
+        Example request body::
+
+            [
+                {"id": 1, "hostname": "device-a.local"},
+                {"id": 2, "ip_address": "10.0.0.5", "os": "Linux"}
+            ]
+        """
+        if not isinstance(request.data, list):
+            return Response(
+                {"detail": "Expected a list of objects."},
+                status=status.HTTP_400_BAD_REQUEST,
             )
-        )
+
+        results = []
+        for item in request.data:
+            asset_id = item.get("id")
+            if asset_id is None:
+                return Response(
+                    {"detail": "Each item must include an 'id' field."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            try:
+                asset = Asset.objects.get(pk=asset_id)
+            except Asset.DoesNotExist:
+                return Response(
+                    {"detail": f"Asset with id={asset_id} not found."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            serializer = AssetSerializer(
+                asset, data=item, partial=True, context={"request": request}
+            )
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
+            results.append(serializer.data)
+
+        return Response(results, status=status.HTTP_200_OK)
 
     @action(detail=False, methods=["POST"])
-    def upsert(self, request):
-        """Update or create an Asset.
+    def upsert(self, request: Request) -> Response:
+        """Update or create an Asset (DEPRECATED).
+
+        .. deprecated::
+            Use ``PATCH /api/assets/`` for single updates or
+            ``PATCH /api/assets/bulk_update/`` for batch updates.
+            This endpoint will be removed in a future release.
 
         The input is a JSON blob containing any Asset field.  The output is a
         copy of the updated or created asset.  The status code is 201 upon
@@ -1000,6 +969,11 @@ class AssetViewSet(
         The name "upsert" is a portmanteau of "UPDATE" and "INSERT" and is
         borrowed from database management.
         """
+        logger.warning(
+            "POST /api/assets/upsert/ is deprecated and will be removed in a future "
+            "release. Use PATCH /api/assets/<id>/ for single updates or "
+            "PATCH /api/assets/bulk_update/ for batch updates."
+        )
         # Ignore API calls that lack a MAC address.  Otherwise, we'd create
         # duplicate assets with each call!  The reason is because MAC is the
         # only way we can uniquely identify an asset for *update*.
@@ -1061,7 +1035,12 @@ class AssetViewSet(
         # Serialize the created or updated asset object and return it in the
         # response.
         serializer = AssetSerializer(asset, context={"request": request})
-        return Response(
+        response = Response(
             serializer.data,
             status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
         )
+        response["Deprecation"] = "true"
+        response["Link"] = (
+            '</api/assets/bulk_update/>; rel="successor-version"'
+        )
+        return response

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -932,6 +932,7 @@ class AssetViewSet(
 
         # Phase 1: normalise and validate every item before touching the DB.
         validated: list[tuple[Asset, AssetSerializer]] = []
+        seen_ids: set[int] = set()
         for item in request.data:
             asset_id = item.get("id")
             if asset_id is None:
@@ -939,6 +940,12 @@ class AssetViewSet(
                     {"detail": "Each item must include an 'id' field."},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
+            if asset_id in seen_ids:
+                return Response(
+                    {"detail": f"Duplicate id in request: {asset_id}."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            seen_ids.add(asset_id)
 
             # Apply the same field normalisations as create/update.
             if "open_ports_tcp" in item:

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -974,8 +974,10 @@ class AssetViewSet(
         """Update or create an Asset (DEPRECATED).
 
         .. deprecated::
-            Use ``PATCH /api/assets/`` for single updates or
-            ``PATCH /api/assets/bulk_update/`` for batch updates.
+            Use ``PATCH /api/assets/<id>/`` for single updates.
+            ``PATCH /api/assets/bulk_update/`` supports batch partial-updates
+            only — it does not provide create-or-update-by-identity semantics
+            and is not a drop-in replacement for this endpoint.
             This endpoint will be removed in a future release.
 
         The input is a JSON blob containing any Asset field.  The output is a
@@ -987,8 +989,9 @@ class AssetViewSet(
         """
         logger.warning(
             "POST /api/assets/upsert/ is deprecated and will be removed in a future "
-            "release. Use PATCH /api/assets/<id>/ for single updates or "
-            "PATCH /api/assets/bulk_update/ for batch updates."
+            "release. Use PATCH /api/assets/<id>/ for single updates. "
+            "Note: PATCH /api/assets/bulk_update/ is for batch partial-updates only "
+            "and is not a drop-in replacement."
         )
         # Ignore API calls that lack a MAC address.  Otherwise, we'd create
         # duplicate assets with each call!  The reason is because MAC is the
@@ -1069,7 +1072,5 @@ class AssetViewSet(
             status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
         )
         response["Deprecation"] = "true"
-        response["Link"] = (
-            '</api/assets/bulk_update/>; rel="successor-version"'
-        )
+        response["Link"] = '</api/assets/{id}/>; rel="successor-version"'
         return response

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -3,7 +3,7 @@
 import importlib
 import logging
 import re
-from typing import ClassVar
+from typing import ClassVar, Any
 
 import django_filters
 import django_filters.rest_framework.filters as drf_filters
@@ -513,50 +513,33 @@ class AssetViewSet(
             context["header"] = default_headers
         return context
 
-    @staticmethod
-    def _ports_string_to_list(ports_string: str | None) -> list:
-        """Convert string of integers to a sorted list of unique integers.
+    def _validate_open_ports(self, ports: Any) -> list[str]:
+        """Convert TCP port string to list.
+        Convert string of integers to a sorted list of unique integers.
 
         Separator(s) can be one of: space, comma, semicolon, pipe, or newline,
         including repetitions of these.
 
-        Added bonus: if None, return empty list.
+        Added bonus: if falsey, return empty list.
         """
-        if ports_string is None or ports_string == "":
+        if not ports:
             return []
+        if not isinstance(ports, str):
+            return ports
 
         sep_re = re.compile(r"[ ,;|\n]+")
-        try:
-            ports_list = re.split(sep_re, ports_string)
-        except TypeError:
-            # Apparently ports_string wasn't a string.
-            return ports_string
-
+        ports_list = re.split(sep_re, ports)
         return ports_list
 
-    def _validate_open_ports(self, request: Request) -> None:
-        """Convert TCP port string to list.
-
-        Modifies the 'request' in-place.
-        """
-        if "open_ports_tcp" in request.data:
-            request.data["open_ports_tcp"] = self._ports_string_to_list(
-                request.data["open_ports_tcp"]
-            )
-
     @staticmethod
-    def _validate_mac_address(request: Request) -> None:
+    def _validate_mac_address(mac: str | None) -> str | None:
         """Convert an empty string MAC address to None.
 
         This would happen at a later point, but doing it explicitly here
         avoids a database error due to "non-unique" MAC when there's an
         existing empty MAC address.
-
-        Modifies the 'request' in-place.
         """
-        if request.data.get("mac_address") == "":
-            logger.debug("Coercing empty string MAC to None")
-            request.data["mac_address"] = None
+        return mac if mac else None
 
     def update(self, request: Request, *args: int, **kwargs: str) -> Response:
         """Override update in order to convert TCP port string to list.
@@ -564,8 +547,10 @@ class AssetViewSet(
         NOTE: We can't use a "serializer validator" for this, since the
         validator would kick a string out (it really wants a list.)
         """
-        self._validate_open_ports(request)
-        self._validate_mac_address(request)
+        if "open_ports_tcp" in request.data:
+            request.data['open_ports_tcp'] = self._validate_open_ports(request.data['open_ports_tcp'])
+        if "mac_address" in request.data:
+            request.data['mac_address'] = self._validate_mac_address(request.data['mac_address'])
         return super().update(request, *args, **kwargs)
 
     def create(self, request: Request, *args: int, **kwargs: str) -> Response:
@@ -573,8 +558,10 @@ class AssetViewSet(
 
         NOTE: (see 'update' method)
         """
-        self._validate_open_ports(request)
-        self._validate_mac_address(request)
+        if "open_ports_tcp" in request.data:
+            request.data['open_ports_tcp'] = self._validate_open_ports(request.data['open_ports_tcp'])
+        if "mac_address" in request.data:
+            request.data['mac_address'] = self._validate_mac_address(request.data['mac_address'])
         return super().create(request, *args, **kwargs)
 
     ################################
@@ -949,11 +936,9 @@ class AssetViewSet(
 
             # Apply the same field normalisations as create/update.
             if "open_ports_tcp" in item:
-                item["open_ports_tcp"] = self._ports_string_to_list(item["open_ports_tcp"])
-            if item.get("mac_address") == "":
-                logger.debug("Coercing empty string MAC to None")
-                item["mac_address"] = None
-
+                item["open_ports_tcp"] = self._validate_open_ports(item["open_ports_tcp"])
+            if "mac_address" in item:
+                item["mac_address"] = self._validate_mac_address(item["mac_address"])
             try:
                 asset = Asset.objects.get(pk=asset_id)
             except Asset.DoesNotExist:

--- a/conftest.py
+++ b/conftest.py
@@ -22,7 +22,7 @@ def pytest_ignore_collect(path, config):
 
 
 @pytest.fixture
-def enable_core_switch():
+def enable_core_switch(db):
     """Enable the 'core' waffle switch so API views (e.g. /assets/) are allowed in tests."""
     from waffle.testutils import override_switch
 

--- a/project/settings/test.py
+++ b/project/settings/test.py
@@ -35,5 +35,3 @@ DATABASES = {
 
 MEDIA_ROOT = tempfile.mkdtemp(prefix="blueflow_test_media_")
 MEDIA_URL = "/media/"
-
-WAFFLE_SWITCH_DEFAULT = True

--- a/project/settings/test.py
+++ b/project/settings/test.py
@@ -1,23 +1,29 @@
-"""Minimal Django settings for blueflow tests (pytest). Use DJANGO_SETTINGS_MODULE=project.settings.test."""
+"""Minimal Django settings for blueflow tests (pytest).
+
+Use DJANGO_SETTINGS_MODULE=project.settings.test.
+"""
 
 import os
 import tempfile
 
-from .base import *
+import dj_database_url
 
-SECRET_KEY = "test-secret-key-not-for-production"
+from .base import *  # noqa: F403
+
+SECRET_KEY = "test-secret-key-not-for-production"  # noqa: S105
 DEBUG = True
 ALLOWED_HOSTS = ["*"]
 WSGI_APPLICATION = "project.wsgi.application"
 
-# Tests require PostgreSQL. Set DATABASE_URL (e.g. postgresql://blueflow:blueflow@localhost:5432/blueflow).
+# Tests require PostgreSQL. Set DATABASE_URL (e.g.
+# postgresql://blueflow:blueflow@localhost:5432/blueflow).
 _database_url = os.environ.get("DATABASE_URL")
 if not _database_url:
-    raise RuntimeError(
-        "Tests require PostgreSQL; set DATABASE_URL (e.g. postgresql://blueflow:blueflow@localhost:5432/blueflow)"
+    _msg = (
+        "Tests require PostgreSQL; set DATABASE_URL"
+        " (e.g. postgresql://blueflow:blueflow@localhost:5432/blueflow)"
     )
-
-import dj_database_url
+    raise RuntimeError(_msg)
 
 DATABASES = {
     "default": dj_database_url.parse(
@@ -29,3 +35,5 @@ DATABASES = {
 
 MEDIA_ROOT = tempfile.mkdtemp(prefix="blueflow_test_media_")
 MEDIA_URL = "/media/"
+
+WAFFLE_SWITCH_DEFAULT = True


### PR DESCRIPTION
# Summary
- Adds `PATCH /api/assets/bulk_update/` for partial bulk updates by asset `id`
- Deprecates `POST /api/assets/upsert/` with `Deprecation: true` + `Link` response headers, server-side log warning, and updated docstring
- Migrates and extends tests: partial update, bulk update, mixed valid/invalid IDs, and idempotency

Closes #51

# Pics

## Deprecation link in old endpoint

<img width="1512" height="349" alt="Screenshot 2026-03-30 at 10 10 08" src="https://github.com/user-attachments/assets/4dda680d-ce17-44fa-bfca-ac1a942048d6" />

## New endpoint works

<img width="1509" height="368" alt="Screenshot 2026-03-30 at 10 13 23" src="https://github.com/user-attachments/assets/16be7934-e31b-4985-8cbb-767e149dce24" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk PATCH endpoint to update multiple assets in one request; validates payloads, normalizes fields, and saves atomically.

* **Deprecations**
  * Upsert endpoint marked deprecated; responses include deprecation info and a link to the bulk-update successor.

* **Bug Fixes**
  * Asset serialization now returns concrete model fields for accurate diffs/updates.

* **Tests**
  * Added comprehensive bulk-update tests, replaced numeric status assertions with HTTP status constants, and added type hints.

* **Chores**
  * Test settings and fixtures adjusted (test DB fixture dependency added; one auth fixture removed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->