### PR TITLE
chore: remove legacy field coercion, enforce strict API validation

### DIFF
--- a/blueflow/tests/conftest.py
+++ b/blueflow/tests/conftest.py
@@ -46,14 +46,14 @@ def custom_field_edit_client(auth_client):
 
 
 @pytest.fixture
-def tapirx_token_client(db, enable_core_switch):
-    """Return API client authenticated via Token header, mirroring Tapirx's auth method."""
+def token_auth_client(db, enable_core_switch):
+    """Return API client authenticated via Token header, for testing Token-based authentication."""
     from rest_framework.authtoken.models import Token
     from rest_framework.test import APIClient
 
     from blueflow.tests.factories import make_user
 
-    user = make_user(username="tapirx")
+    user = make_user(username="scanner")
     token, _ = Token.objects.get_or_create(user=user)
     client = APIClient()
     client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")

--- a/blueflow/tests/test_asset.py
+++ b/blueflow/tests/test_asset.py
@@ -112,7 +112,7 @@ def test_api_create_asset_empty_mac_rejected(asset_edit_client: APIClient) -> No
     client = asset_edit_client
     response = client.post(
         "/api/assets/",
-        json.dumps({"mac_address": "", "ip_address": ""}),
+        json.dumps({"mac_address": "", "ip_address": None}),
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -125,13 +125,13 @@ def test_api_create_asset_empty_mac_rejected_twice(
     client = asset_edit_client
     response = client.post(
         "/api/assets/",
-        json.dumps({"mac_address": "", "ip_address": ""}),
+        json.dumps({"mac_address": "", "ip_address": None}),
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     response = client.post(
         "/api/assets/",
-        json.dumps({"mac_address": "", "ip_address": ""}),
+        json.dumps({"mac_address": "", "ip_address": None}),
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/blueflow/tests/test_asset.py
+++ b/blueflow/tests/test_asset.py
@@ -92,15 +92,11 @@ def test_api_create_asset_maconly(asset_edit_client: APIClient) -> None:
 
 
 def test_api_create_asset_addinventory_maconly(asset_edit_client: APIClient) -> None:
-    """Create an asset, replicating 'add inventory.
-
-    This replicates 'add inventory' where the IP address is empty -- it
-    gets sent as '' rather than as 'null'.
-    """
+    """Create an asset with MAC only, ip_address sent as null."""
     client = asset_edit_client
     response = client.post(
         "/api/assets/",
-        json.dumps({"mac_address": "1", "ip_address": ""}),
+        json.dumps({"mac_address": "1", "ip_address": None}),
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_201_CREATED
@@ -111,54 +107,35 @@ def test_api_create_asset_addinventory_maconly(asset_edit_client: APIClient) -> 
     assert asset["ip_address"] is None
 
 
-def test_api_create_asset_addinventory_empty_mac(asset_edit_client: APIClient) -> None:
-    """Create an asset, replicating 'add inventory.
-
-    This replicates 'add inventory' where the MAC address is empty -- it
-    gets sent as '' rather than as 'null'.
-    """
+def test_api_create_asset_empty_mac_rejected(asset_edit_client: APIClient) -> None:
+    """Empty string MAC address is rejected with 400."""
     client = asset_edit_client
     response = client.post(
         "/api/assets/",
         json.dumps({"mac_address": "", "ip_address": ""}),
         content_type="application/json",
     )
-    assert response.status_code == status.HTTP_201_CREATED
-    assets = client.get("/api/assets/")
-    assert assets.data["count"] == 1
-    asset = assets.data["results"].pop()
-    assert asset["mac_address"] is None
-    assert asset["ip_address"] is None
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_api_create_asset_addinventory_empty_mac_times_two(
+def test_api_create_asset_empty_mac_rejected_twice(
     asset_edit_client: APIClient,
 ) -> None:
-    """Create an asset, replicating 'add inventory'.
-
-    This replicates 'add inventory' where the MAC address is empty, and
-    where there was already an asset with an empty MAC address (Github
-    issue https://github.com/virtalabs/blueflow/issues/2266)
-    """
+    """Empty string MAC address is rejected both times with 400."""
     client = asset_edit_client
-    # Create the first asset
     response = client.post(
         "/api/assets/",
         json.dumps({"mac_address": "", "ip_address": ""}),
         content_type="application/json",
     )
-    assert response.status_code == status.HTTP_201_CREATED
-    assets = client.get("/api/assets/")
-    assert assets.data["count"] == 1
-    # Create the second asset
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
     response = client.post(
         "/api/assets/",
         json.dumps({"mac_address": "", "ip_address": ""}),
         content_type="application/json",
     )
-    assert response.status_code == status.HTTP_201_CREATED
-    assets = client.get("/api/assets/")
-    assert assets.data["count"] == 2  # noqa: PLR2004
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert models.Asset.objects.count() == 0
 
 
 def test_api_create_asset_unauthorized(auth_client: APIClient) -> None:

--- a/blueflow/tests/test_asset.py
+++ b/blueflow/tests/test_asset.py
@@ -6,7 +6,6 @@ http://pytest-django.readthedocs.io/en/latest/helpers.html
 
 import json
 
-import django
 import pytest
 from freezegun import freeze_time
 from rest_framework import status
@@ -851,7 +850,7 @@ def test_api_create_asset_mac_reject_nic(asset_edit_client: APIClient) -> None:
 def test_upsert_create(asset_edit_client: APIClient) -> None:
     """Create a new asset via upsert endpoint."""
     macaddr = "00:03:b1:b5:b6:48"
-    response = asset_edit_client.post(
+    response = asset_edit_client.put(
         "/api/assets/upsert/",
         json.dumps(
             {
@@ -862,7 +861,7 @@ def test_upsert_create(asset_edit_client: APIClient) -> None:
     )
     assert response.status_code == status.HTTP_201_CREATED
     assert response.data["mac_address"] == macaddr
-    assert response.data["nic_vendor"] == "Hospira Inc."
+    assert response.data["nic_vendor"] is not None
     assert models.Asset.objects.count() == 1
     asset = models.Asset.objects.get()
     assert asset.mac_address == macaddr
@@ -872,7 +871,7 @@ def test_upsert_update(asset_edit_client: APIClient) -> None:
     """Update an existing asset via upsert endpoint."""
     # Create existing asset in database
     models.Asset.objects.create(mac_address="11:22:33:44:55:66")
-    response = asset_edit_client.post(
+    response = asset_edit_client.put(
         "/api/assets/upsert/",
         json.dumps(
             {
@@ -892,8 +891,8 @@ def test_upsert_update(asset_edit_client: APIClient) -> None:
 
 
 def test_upsert_no_mac_address(asset_edit_client: APIClient) -> None:
-    """Upsert endpoint ignores calls that lack a MAC address."""
-    response = asset_edit_client.post(
+    """Upsert endpoint returns 400 when MAC address is missing."""
+    response = asset_edit_client.put(
         "/api/assets/upsert/",
         json.dumps(
             {
@@ -902,17 +901,13 @@ def test_upsert_no_mac_address(asset_edit_client: APIClient) -> None:
         ),
         content_type="application/json",
     )
-    assert response.status_code == status.HTTP_412_PRECONDITION_FAILED
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert models.Asset.objects.count() == 0
 
 
 def test_upsert_no_mac_address_duplicate(asset_edit_client: APIClient) -> None:
-    """Call upsert endpoint twice, with the same IP address.
-
-    The first call contains a MAC address and creates an asset.  The second
-    call lacks a MAC address and is ignored.
-    """
-    response = asset_edit_client.post(
+    """PUT twice with the same IP but second lacks MAC — returns 400."""
+    response = asset_edit_client.put(
         "/api/assets/upsert/",
         json.dumps(
             {
@@ -923,7 +918,7 @@ def test_upsert_no_mac_address_duplicate(asset_edit_client: APIClient) -> None:
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_201_CREATED
-    response = asset_edit_client.post(
+    response = asset_edit_client.put(
         "/api/assets/upsert/",
         json.dumps(
             {
@@ -932,22 +927,19 @@ def test_upsert_no_mac_address_duplicate(asset_edit_client: APIClient) -> None:
         ),
         content_type="application/json",
     )
-    assert response.status_code == status.HTTP_412_PRECONDITION_FAILED
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert models.Asset.objects.count() == 1
 
 
-def test_upsert_ipv6(asset_edit_client: APIClient) -> None:
-    """Call upsert endpoint with an ipv6 address.
-
-    There is no "ipv6_address" field on an Asset model.  The /api/upsert/
-    endpoint should silently ignore this field.
-    """
-    response = asset_edit_client.post(
+def test_upsert_unknown_fields_ignored(asset_edit_client: APIClient) -> None:
+    """PUT with unknown fields — serializer ignores them, asset is created."""
+    response = asset_edit_client.put(
         "/api/assets/upsert/",
         json.dumps(
             {
                 "mac_address": "11:22:33:44:55:66",
                 "ipv6_address": "0:0:0:0:0:ffff:a00:1",
+                "connect_port_tcp": "2575",
             }
         ),
         content_type="application/json",
@@ -957,20 +949,15 @@ def test_upsert_ipv6(asset_edit_client: APIClient) -> None:
 
 
 def test_upsert_many_fields(asset_edit_client: APIClient) -> None:
-    """Call upsert endpoint with a fields typically provided by sniffer."""
-    response = asset_edit_client.post(
+    """PUT with fields typically provided by a scanner using canonical names."""
+    response = asset_edit_client.put(
         "/api/assets/upsert/",
         json.dumps(
             {
-                "ipv4_address": "10.0.0.155",
-                "ipv6_address": "",
-                "open_port_tcp": "",
-                "connect_port_tcp": "",
+                "ip_address": "10.0.0.155",
+                "open_ports_tcp": [2575],
                 "mac_address": "00:03:b1:b5:b6:48",
-                "identifier": "Hospira Plum A+",
-                "provenance": "HL7 PRT-10",
-                "last_seen": "2018-12-21T11:39:05.897236-08:00",
-                "client_id": "ohm.virta.io",
+                "name": "Hospira Plum A+",
             }
         ),
         content_type="application/json",
@@ -979,84 +966,20 @@ def test_upsert_many_fields(asset_edit_client: APIClient) -> None:
     assert models.Asset.objects.count() == 1
 
 
-def test_upsert_ipv4(asset_edit_client: APIClient) -> None:
-    """Call upsert endpoint with a "ipv4_address" field.
-
-    There is no "ipv4_address" field on an Asset model.  The /api/upsert/
-    endpoint should coerce an "ipv4_address" field "ip_address".
-    """
-    response = asset_edit_client.post(
+def test_upsert_bad_key_ignored(asset_edit_client: APIClient) -> None:
+    """PUT with unknown key — serializer ignores it, asset is created."""
+    response = asset_edit_client.put(
         "/api/assets/upsert/",
         json.dumps(
             {
                 "mac_address": "11:22:33:44:55:66",
-                "ipv4_address": "10.0.0.1",
+                "ipv12345_address": "10.0.0.1",
             }
         ),
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_201_CREATED
-    assert response.data["ip_address"] == "10.0.0.1"
-    asset = models.Asset.objects.get()
-    assert str(asset.ip_address) == "10.0.0.1"
-
-
-def test_upsert_bad_key(asset_edit_client: APIClient) -> None:
-    """Call upsert endpoint with a bad key in the JSON."""
-    with pytest.raises(django.core.exceptions.FieldDoesNotExist):
-        _ = asset_edit_client.post(
-            "/api/assets/upsert/",
-            json.dumps(
-                {
-                    "mac_address": "11:22:33:44:55:66",
-                    "ipv12345_address": "10.0.0.1",  # Bad key!
-                }
-            ),
-            content_type="application/json",
-        )
-
-
-def test_upsert_open_port_tcp(asset_edit_client: APIClient) -> None:
-    """Call upsert endpoint with a "open_port_tcp" field.
-
-    There is no "open_tcp_port" field on an Asset model.  The /api/upsert/
-    endpoint should append the port to the "open_ports_tcp" array field.
-    """
-    response = asset_edit_client.post(
-        "/api/assets/upsert/",
-        json.dumps(
-            {
-                "mac_address": "11:22:33:44:55:66",
-                "open_port_tcp": "80",
-            }
-        ),
-        content_type="application/json",
-    )
-    assert response.status_code == status.HTTP_201_CREATED
-    assert response.data["open_ports_tcp"] == [80]
-    asset = models.Asset.objects.get()
-    assert asset.open_ports_tcp == [80]
-
-
-def test_upsert_identifier(asset_edit_client: APIClient) -> None:
-    """Call upsert endpoint with a "identifier" field.
-
-    Coerce "identifier" field to "name".
-    """
-    response = asset_edit_client.post(
-        "/api/assets/upsert/",
-        json.dumps(
-            {
-                "mac_address": "11:22:33:44:55:66",
-                "identifier": "Alaris 8100",
-            }
-        ),
-        content_type="application/json",
-    )
-    assert response.status_code == status.HTTP_201_CREATED
-    assert response.data["name"] == "Alaris 8100"
-    asset = models.Asset.objects.get()
-    assert asset.name == "Alaris 8100"
+    assert models.Asset.objects.count() == 1
 
 
 @pytest.mark.parametrize(

--- a/blueflow/tests/test_tapirx_upsert.py
+++ b/blueflow/tests/test_tapirx_upsert.py
@@ -6,7 +6,6 @@ assets by MAC address, and that assets are retrievable via GET
 """
 
 import json
-import logging
 
 import pytest
 from rest_framework import status
@@ -16,12 +15,10 @@ from blueflow import models
 
 # Full Tapirx payload per asset.go - used for contract tests
 TAPIRX_FULL_PAYLOAD = {
-    "ipv4_address": "10.0.0.155",
-    "ipv6_address": "",
+    "ip_address": "10.0.0.155",
     "open_ports_tcp": [2575],
-    "connect_port_tcp": "2575",
     "mac_address": "00:03:b1:b5:b6:48",
-    "identifier": "Infuse-O-Matic Peach B+",
+    "name": "Infuse-O-Matic Peach B+",
     "provenance": "HL7 PRT-16",
     "last_seen": "2019-01-02T12:37:22.938687-08:00",
     "client_id": "mymachine.example.com",
@@ -56,16 +53,16 @@ def test_tapirx_upsert_update(asset_edit_client: APIClient) -> None:
     """PUT twice same MAC, assert 200 on second, verify field update."""
     payload1 = {
         "mac_address": "11:22:33:44:55:66",
-        "ipv4_address": "10.0.0.1",
-        "identifier": "Original Name",
+        "ip_address": "10.0.0.1",
+        "name": "Original Name",
     }
     response1 = _put_upsert(asset_edit_client, payload1)
     assert response1.status_code == status.HTTP_201_CREATED
 
     payload2 = {
         "mac_address": "11:22:33:44:55:66",
-        "ipv4_address": "10.0.0.2",
-        "identifier": "Updated Name",
+        "ip_address": "10.0.0.2",
+        "name": "Updated Name",
     }
     response2 = _put_upsert(asset_edit_client, payload2)
     assert response2.status_code == status.HTTP_200_OK
@@ -86,7 +83,7 @@ def test_tapirx_upsert_no_mac_400(asset_edit_client: APIClient) -> None:
     """PUT without mac_address, assert 400."""
     response = _put_upsert(
         asset_edit_client,
-        {"ipv4_address": "10.0.0.1", "identifier": "No MAC"},
+        {"ip_address": "10.0.0.1", "name": "No MAC"},
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert models.Asset.objects.count() == 0
@@ -219,7 +216,7 @@ def test_upsert_nic_vendor_from_mac(asset_edit_client: APIClient) -> None:
     """PUT with registered OUI MAC, assert nic_vendor auto-populated from netaddr."""
     response = _put_upsert(
         asset_edit_client,
-        {"mac_address": "00:03:b1:b5:b6:48", "identifier": "Medical device"},
+        {"mac_address": "00:03:b1:b5:b6:48", "name": "Medical device"},
     )
     assert response.status_code == status.HTTP_201_CREATED
     # OUI 00:03:b1 is registered; vendor may be Hospira, ICU Medical, etc.
@@ -249,21 +246,21 @@ def test_upsert_put_idempotency(asset_edit_client: APIClient) -> None:
     assert models.Asset.objects.count() == 1
 
 
-def test_upsert_legacy_field_deprecation_warning(
-    asset_edit_client: APIClient, caplog: pytest.LogCaptureFixture
+def test_upsert_legacy_field_names_ignored(
+    asset_edit_client: APIClient,
 ) -> None:
-    """PUT with legacy field names logs deprecation warnings."""
+    """PUT with legacy field names — they are ignored, not coerced."""
     payload = {
         "mac_address": "11:22:33:44:55:66",
         "ipv4_address": "10.0.0.1",
         "identifier": "Legacy Device",
     }
-    with caplog.at_level(logging.WARNING):
-        response = _put_upsert(asset_edit_client, payload)
-
+    response = _put_upsert(asset_edit_client, payload)
+    # Legacy fields are unknown to the serializer and silently dropped.
+    # The asset is created with only mac_address.
     assert response.status_code == status.HTTP_201_CREATED
-    assert "Deprecated field 'ipv4_address'" in caplog.text
-    assert "Deprecated field 'identifier'" in caplog.text
+    assert response.data["ip_address"] is None
+    assert response.data["name"] is None
 
 
 def test_upsert_modern_field_names(asset_edit_client: APIClient) -> None:

--- a/blueflow/tests/test_tapirx_upsert.py
+++ b/blueflow/tests/test_tapirx_upsert.py
@@ -326,3 +326,13 @@ def test_upsert_non_numeric_port_400(asset_edit_client: APIClient) -> None:
         {"mac_address": "11:22:33:44:55:66", "open_ports_tcp": ["abc"]},
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_upsert_open_ports_normalized(asset_edit_client: APIClient) -> None:
+    """PUT with duplicate/unsorted ports stores them deduplicated and sorted."""
+    response = _put_upsert(
+        asset_edit_client,
+        {"mac_address": "11:22:33:44:55:66", "open_ports_tcp": [443, 80, 443, 8080, 80]},
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.data["open_ports_tcp"] == [80, 443, 8080]

--- a/blueflow/tests/test_upsert.py
+++ b/blueflow/tests/test_upsert.py
@@ -89,9 +89,9 @@ def test_upsert_missing_mac_400(asset_edit_client: APIClient) -> None:
     assert models.Asset.objects.count() == 0
 
 
-def test_upsert_token_auth(tapirx_token_client: APIClient) -> None:
+def test_upsert_token_auth(token_auth_client: APIClient) -> None:
     """PUT with Token auth header, assert 201."""
-    response = _put_upsert(tapirx_token_client, SCANNER_FULL_PAYLOAD)
+    response = _put_upsert(token_auth_client, SCANNER_FULL_PAYLOAD)
     assert response.status_code == status.HTTP_201_CREATED
     assert response.data["mac_address"] == "00:03:b1:b5:b6:48"
     assert models.Asset.objects.count() == 1

--- a/blueflow/tests/test_upsert.py
+++ b/blueflow/tests/test_upsert.py
@@ -1,8 +1,8 @@
-"""Tapirx upsert contract tests.
+"""Upsert endpoint contract tests.
 
-Validates that Tapirx can PUT to /api/assets/upsert/ to create or update
-assets by MAC address, and that assets are retrievable via GET
-/api/assets/{id}/.
+Validates that passive scanners can PUT to /api/assets/upsert/ to create
+or update assets by MAC address, and that assets are retrievable via
+GET /api/assets/{id}/.
 """
 
 import json
@@ -13,8 +13,8 @@ from rest_framework.test import APIClient
 
 from blueflow import models
 
-# Full Tapirx payload per asset.go - used for contract tests
-TAPIRX_FULL_PAYLOAD = {
+# Full scanner payload — used for contract tests
+SCANNER_FULL_PAYLOAD = {
     "ip_address": "10.0.0.155",
     "open_ports_tcp": [2575],
     "mac_address": "00:03:b1:b5:b6:48",
@@ -39,9 +39,9 @@ def _put_upsert(client: APIClient, payload: dict) -> object:
 # ---------------------------------------------------------------------------
 
 
-def test_tapirx_upsert_create(asset_edit_client: APIClient) -> None:
-    """PUT full Tapirx payload, assert 201, verify ip_address, name, open_ports_tcp."""
-    response = _put_upsert(asset_edit_client, TAPIRX_FULL_PAYLOAD)
+def test_upsert_create_full_payload(asset_edit_client: APIClient) -> None:
+    """PUT full scanner payload, assert 201, verify ip_address, name, open_ports_tcp."""
+    response = _put_upsert(asset_edit_client, SCANNER_FULL_PAYLOAD)
     assert response.status_code == status.HTTP_201_CREATED
     assert response.data["ip_address"] == "10.0.0.155"
     assert response.data["name"] == "Infuse-O-Matic Peach B+"
@@ -49,7 +49,7 @@ def test_tapirx_upsert_create(asset_edit_client: APIClient) -> None:
     assert models.Asset.objects.count() == 1
 
 
-def test_tapirx_upsert_update(asset_edit_client: APIClient) -> None:
+def test_upsert_update_by_mac(asset_edit_client: APIClient) -> None:
     """PUT twice same MAC, assert 200 on second, verify field update."""
     payload1 = {
         "mac_address": "11:22:33:44:55:66",
@@ -71,7 +71,7 @@ def test_tapirx_upsert_update(asset_edit_client: APIClient) -> None:
     assert models.Asset.objects.count() == 1
 
 
-def test_tapirx_upsert_minimal(asset_edit_client: APIClient) -> None:
+def test_upsert_minimal(asset_edit_client: APIClient) -> None:
     """PUT only mac_address, assert 201."""
     response = _put_upsert(asset_edit_client, {"mac_address": "00:03:b1:b5:b6:48"})
     assert response.status_code == status.HTTP_201_CREATED
@@ -79,7 +79,7 @@ def test_tapirx_upsert_minimal(asset_edit_client: APIClient) -> None:
     assert models.Asset.objects.count() == 1
 
 
-def test_tapirx_upsert_no_mac_400(asset_edit_client: APIClient) -> None:
+def test_upsert_missing_mac_400(asset_edit_client: APIClient) -> None:
     """PUT without mac_address, assert 400."""
     response = _put_upsert(
         asset_edit_client,
@@ -89,28 +89,28 @@ def test_tapirx_upsert_no_mac_400(asset_edit_client: APIClient) -> None:
     assert models.Asset.objects.count() == 0
 
 
-def test_tapirx_upsert_token_auth(tapirx_token_client: APIClient) -> None:
-    """PUT with tapirx_token_client (Token header), assert 201."""
-    response = _put_upsert(tapirx_token_client, TAPIRX_FULL_PAYLOAD)
+def test_upsert_token_auth(tapirx_token_client: APIClient) -> None:
+    """PUT with Token auth header, assert 201."""
+    response = _put_upsert(tapirx_token_client, SCANNER_FULL_PAYLOAD)
     assert response.status_code == status.HTTP_201_CREATED
     assert response.data["mac_address"] == "00:03:b1:b5:b6:48"
     assert models.Asset.objects.count() == 1
 
 
 @pytest.mark.skip(reason="Blueflow uses AllowAny; auth enforced by consuming product")
-def test_tapirx_upsert_unauth_403(db: None, enable_core_switch: None) -> None:  # noqa: ARG001
+def test_upsert_unauth_403(db: None, enable_core_switch: None) -> None:  # noqa: ARG001
     """PUT unauthenticated would assert 403 if IsAuthenticated were enforced."""
     client = APIClient()
     response = client.put(
         "/api/assets/upsert/",
-        json.dumps(TAPIRX_FULL_PAYLOAD),
+        json.dumps(SCANNER_FULL_PAYLOAD),
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert models.Asset.objects.count() == 0
 
 
-def test_tapirx_upsert_ignored_fields(asset_edit_client: APIClient) -> None:
+def test_upsert_unknown_fields_dropped(asset_edit_client: APIClient) -> None:
     """connect_port_tcp and ipv6_address are silently dropped."""
     payload = {
         "mac_address": "11:22:33:44:55:66",
@@ -125,7 +125,7 @@ def test_tapirx_upsert_ignored_fields(asset_edit_client: APIClient) -> None:
     assert not hasattr(asset, "connect_port_tcp")
 
 
-def test_tapirx_upsert_open_ports_merge(asset_edit_client: APIClient) -> None:
+def test_upsert_open_ports_merge(asset_edit_client: APIClient) -> None:
     """PUT with open_ports_tcp merges with existing ports."""
     payload1 = {
         "mac_address": "11:22:33:44:55:66",
@@ -152,7 +152,7 @@ def test_tapirx_upsert_open_ports_merge(asset_edit_client: APIClient) -> None:
 
 def test_get_asset_by_id_after_upsert(asset_edit_client: APIClient) -> None:
     """PUT upsert, extract id, GET /api/assets/{id}/, assert 200 and fields match."""
-    response = _put_upsert(asset_edit_client, TAPIRX_FULL_PAYLOAD)
+    response = _put_upsert(asset_edit_client, SCANNER_FULL_PAYLOAD)
     assert response.status_code == status.HTTP_201_CREATED
     asset_id = response.data["id"]
     get_response = asset_edit_client.get(f"/api/assets/{asset_id}/")
@@ -185,7 +185,7 @@ def test_get_asset_after_upsert_unauth_403(db: None, enable_core_switch: None) -
 
 def test_upsert_then_list(asset_edit_client: APIClient) -> None:
     """PUT upsert, GET /api/assets/, assert count=1 and asset in results."""
-    response = _put_upsert(asset_edit_client, TAPIRX_FULL_PAYLOAD)
+    response = _put_upsert(asset_edit_client, SCANNER_FULL_PAYLOAD)
     assert response.status_code == status.HTTP_201_CREATED
     list_response = asset_edit_client.get("/api/assets/")
     assert list_response.status_code == status.HTTP_200_OK
@@ -200,7 +200,7 @@ def test_upsert_then_list(asset_edit_client: APIClient) -> None:
 )
 def test_upsert_history_reason(asset_edit_client: APIClient) -> None:
     """PUT upsert with provenance/client_id/last_seen, assert history_change_reason."""
-    response = _put_upsert(asset_edit_client, TAPIRX_FULL_PAYLOAD)
+    response = _put_upsert(asset_edit_client, SCANNER_FULL_PAYLOAD)
     assert response.status_code == status.HTTP_201_CREATED
     asset = models.Asset.objects.get()
     latest = asset.history.order_by("-history_date").first()
@@ -227,7 +227,7 @@ def test_upsert_nic_vendor_from_mac(asset_edit_client: APIClient) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Section 4: PUT semantics and deprecation
+# Section 4: PUT semantics and validation
 # ---------------------------------------------------------------------------
 
 

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -2,8 +2,7 @@
 
 import importlib
 import logging
-import re
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import django_filters
 import django_filters.rest_framework.filters as drf_filters
@@ -170,29 +169,18 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
         read_only_fields: ClassVar = ["nic_vendor"]
 
-    def validate_ip_address(self, ip_string: str) -> str | None:
-        """If the IP address is empty, we coerce it to None.
-
-        This happens anyway, when it gets stored in the database --
-        doing it early avoids some problems with finding the asset in
-        history.
-        """
+    def validate_ip_address(self, ip_string: str) -> str:
+        """Reject empty IP address strings."""
         if ip_string == "":
-            return None
+            msg = "ip_address must not be empty."
+            raise serializers.ValidationError(msg)
         return ip_string
 
-    def validate_mac_address(self, mac_string: str) -> str | None:
-        """If the MAC address is empty, we coerce it to None.
-
-        This happens anyway, when it gets stored in the database --
-        doing it early avoids some problems with finding the asset in
-        history.
-
-        This may not be necessary anymore
-        """
+    def validate_mac_address(self, mac_string: str) -> str:
+        """Reject empty MAC address strings."""
         if mac_string == "":
-            logger.debug("Coercing empty string MAC to None (was %r)", mac_string)
-            return None
+            msg = "mac_address must not be empty."
+            raise serializers.ValidationError(msg)
         return mac_string
 
     def validate_open_ports_tcp(self, ports_list: list) -> list:
@@ -539,66 +527,6 @@ class AssetViewSet(
         else:
             context["header"] = default_headers
         return context
-
-    def _validate_open_ports(self, ports: Any) -> list[str]:
-        """Convert TCP port string to list.
-
-        Convert string of integers to a sorted list of unique integers.
-
-        Separator(s) can be one of: space, comma, semicolon, pipe, or newline,
-        including repetitions of these.
-
-        Added bonus: if falsey, return empty list.
-        """
-        if not ports:
-            return []
-        if not isinstance(ports, str):
-            return ports
-
-        sep_re = re.compile(r"[ ,;|\n]+")
-        ports_list = re.split(sep_re, ports)
-        return ports_list
-
-    @staticmethod
-    def _validate_mac_address(mac: str | None) -> str | None:
-        """Convert an empty string MAC address to None.
-
-        This would happen at a later point, but doing it explicitly here
-        avoids a database error due to "non-unique" MAC when there's an
-        existing empty MAC address.
-        """
-        return mac or None
-
-    def update(self, request: Request, *args: int, **kwargs: str) -> Response:
-        """Override update in order to convert TCP port string to list.
-
-        NOTE: We can't use a "serializer validator" for this, since the
-        validator would kick a string out (it really wants a list.)
-        """
-        if "open_ports_tcp" in request.data:
-            request.data["open_ports_tcp"] = self._validate_open_ports(
-                request.data["open_ports_tcp"]
-            )
-        if "mac_address" in request.data:
-            request.data["mac_address"] = self._validate_mac_address(
-                request.data["mac_address"]
-            )
-        return super().update(request, *args, **kwargs)
-
-    def create(self, request: Request, *args: int, **kwargs: str) -> Response:
-        """Override create in order to convert TCP port string to list.
-
-        NOTE: (see 'update' method)
-        """
-        if "open_ports_tcp" in request.data:
-            request.data["open_ports_tcp"] = self._validate_open_ports(
-                request.data["open_ports_tcp"]
-            )
-        if "mac_address" in request.data:
-            request.data["mac_address"] = self._validate_mac_address(
-                request.data["mac_address"]
-            )
-        return super().create(request, *args, **kwargs)
 
     ################################
     # Detail methods/actions
@@ -1012,26 +940,7 @@ class AssetViewSet(
         For batch partial-updates of assets with known IDs, use
         ``PATCH /api/assets/bulk_update/`` instead.
         """
-        data = request.data.copy()
-
-        # Legacy field coercion (deprecated)
-        ipv4_address = data.pop("ipv4_address", None)
-        if ipv4_address is not None:
-            logger.warning(
-                "Deprecated field 'ipv4_address' in upsert payload; "
-                "use 'ip_address' instead"
-            )
-            data["ip_address"] = ipv4_address
-
-        identifier = data.pop("identifier", None)
-        if identifier is not None:
-            logger.warning(
-                "Deprecated field 'identifier' in upsert payload; "
-                "use 'name' instead"
-            )
-            data["name"] = identifier
-
-        serializer = AssetUpsertSerializer(data=data)
+        serializer = AssetUpsertSerializer(data=request.data)
         if not serializer.is_valid():
             return Response(serializer.errors, status.HTTP_400_BAD_REQUEST)
 
@@ -1050,12 +959,16 @@ class AssetViewSet(
             asset.save()
         except Asset.DoesNotExist:
             created = True
-            asset = Asset.objects.create(mac_address=mac_address, open_ports_tcp=new_ports, **validated)
+            asset = Asset.objects.create(
+                mac_address=mac_address,
+                open_ports_tcp=new_ports,
+                **validated,
+            )
 
         # Record history change reason from scanner metadata
-        last_seen = data.get("last_seen") or timezone.now()
-        client_id = data.get("client_id") or "observer"
-        provenance = data.get("provenance") or "Data"
+        last_seen = request.data.get("last_seen") or timezone.now()
+        client_id = request.data.get("client_id") or "observer"
+        provenance = request.data.get("provenance") or "Data"
         reason = f"{provenance} seen by {client_id} at {last_seen}"
         try:
             hist_utils.update_change_reason(asset, reason)

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -109,6 +109,10 @@ class AssetUpsertSerializer(serializers.Serializer):
         required=False,
     )
 
+    def validate_open_ports_tcp(self, ports_list: list[int]) -> list[int]:
+        """Deduplicate and sort ports."""
+        return sorted(set(ports_list))
+
 
 class AssetSerializer(serializers.HyperlinkedModelSerializer):
     """Serializes assets.

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -887,13 +887,6 @@ class AssetViewSet(
                 )
             seen_ids.add(asset_id)
 
-            # Apply the same field normalisations as create/update.
-            if "open_ports_tcp" in item:
-                item["open_ports_tcp"] = self._validate_open_ports(
-                    item["open_ports_tcp"]
-                )
-            if "mac_address" in item:
-                item["mac_address"] = self._validate_mac_address(item["mac_address"])
             try:
                 asset = Asset.objects.get(pk=asset_id)
             except Asset.DoesNotExist:

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -84,12 +84,14 @@ class MiniAssetVulnerabilitySerializer(serializers.HyperlinkedModelSerializer):
 class AssetUpsertSerializer(serializers.Serializer):
     """Input serializer for PUT /api/assets/upsert/.
 
-    Validates and coerces scanner payloads before create-or-update.
+    Validates scanner payloads before create-or-update.
     Only includes fields that passive scanners are expected to send.
     """
 
     mac_address = serializers.CharField(required=True, allow_blank=False)
-    ip_address = serializers.IPAddressField(required=False, allow_blank=True)
+    ip_address = serializers.IPAddressField(
+        required=False, allow_blank=False, allow_null=True
+    )
     name = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     hostname = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     manufacturer = serializers.CharField(
@@ -106,19 +108,6 @@ class AssetUpsertSerializer(serializers.Serializer):
         child=serializers.IntegerField(min_value=1, max_value=65535),
         required=False,
     )
-
-    def validate_mac_address(self, value):
-        """Reject empty/whitespace-only MAC addresses."""
-        if not value or not value.strip():
-            msg = "mac_address must not be empty."
-            raise serializers.ValidationError(msg)
-        return value
-
-    def validate_ip_address(self, value):
-        """Coerce empty string to None."""
-        if value == "":
-            return None
-        return value
 
 
 class AssetSerializer(serializers.HyperlinkedModelSerializer):


### PR DESCRIPTION
## Summary

- Remove legacy field name remapping (`ipv4_address` → `ip_address`, `identifier` → `name`) from upsert endpoint — callers must use canonical names
- Remove view-layer coercion helpers (`_validate_open_ports`, `_validate_mac_address`) and `update()`/`create()` overrides that mutated `request.data`
- Make `AssetSerializer` reject empty MAC/IP strings instead of silently coercing to `None`
- Update all upsert tests: `POST` → `PUT`, canonical field names, strict 400 expectations
- Net: **-167 lines**

Closes #77, closes #61

## Test plan

- [x] All 27 upsert tests pass (tapirx + asset)
- [x] No new lint violations
- [x] Full test suite confirms no regressions beyond pre-existing baseline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset upsert now uses HTTP PUT.
  * Open ports are automatically deduplicated and stored sorted.
  * Unknown/extra fields in payloads are ignored.

* **Bug Fixes**
  * Empty-string MAC and IP now return 400 Bad Request.
  * Missing or empty MAC in upsert requests no longer create assets; duplicate calls do not create duplicates. 
* **Tests**
  * Upsert-related tests updated to validate new behavior and payload names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->