### PR TITLE
Add agent conventions and update-baseline command

### DIFF
--- a/harness/orchestrator.py
+++ b/harness/orchestrator.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import subprocess
 import sys
 from dataclasses import dataclass, field
@@ -138,10 +139,7 @@ def update_baseline_cmd(test_timeout: int, lint_timeout: int) -> None:
         text=True,
         timeout=test_timeout,
         check=False,
-        env={
-            **__import__("os").environ,
-            "DJANGO_SETTINGS_MODULE": "project.settings.test",
-        },
+        env={**os.environ, "DJANGO_SETTINGS_MODULE": "project.settings.test"},
     )
 
     test_report = parse_test_output(test_result.stdout)

--- a/harness/orchestrator.py
+++ b/harness/orchestrator.py
@@ -2,8 +2,10 @@
 
 import json
 import logging
+import subprocess
 import sys
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 
 import click
@@ -106,6 +108,88 @@ def list_eligible_cmd() -> None:
     click.echo("-" * 60)
     for issue in issues:
         click.echo(f"{issue['number']:<6} {issue['title']}")
+
+
+@cli.command("update-baseline")
+@click.option(
+    "--test-timeout",
+    default=300,
+    help="Timeout in seconds for pytest run.",
+)
+@click.option(
+    "--lint-timeout",
+    default=60,
+    help="Timeout in seconds for ruff check.",
+)
+def update_baseline_cmd(test_timeout: int, lint_timeout: int) -> None:
+    """Regenerate baseline.json from current test and lint results."""
+    click.echo("Running pytest to capture test failures...")
+    test_result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "pytest",
+            "-q",
+            "--tb=no",
+            "--no-header",
+            "-ra",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=test_timeout,
+        check=False,
+        env={
+            **__import__("os").environ,
+            "DJANGO_SETTINGS_MODULE": "project.settings.test",
+        },
+    )
+
+    test_report = parse_test_output(test_result.stdout)
+    click.echo(
+        f"  {test_report.failed} failed, "
+        f"{test_report.passed} passed, "
+        f"{test_report.total} total"
+    )
+
+    click.echo("Running ruff check to capture lint violations...")
+    lint_result = subprocess.run(
+        ["uv", "run", "ruff", "check", ".", "--output-format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=lint_timeout,
+        check=False,
+    )
+
+    lint_violations = 0
+    lint_summary: dict[str, int] = {}
+    if lint_result.stdout.strip():
+        violations = json.loads(lint_result.stdout)
+        lint_violations = len(violations)
+        for v in violations:
+            code = v.get("code", "unknown")
+            lint_summary[code] = lint_summary.get(code, 0) + 1
+
+    # Sort summary by count descending for readability
+    lint_summary = dict(sorted(lint_summary.items(), key=lambda x: x[1], reverse=True))
+
+    click.echo(f"  {lint_violations} lint violations across {len(lint_summary)} rules")
+
+    now = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+    baseline = {
+        "_description": (
+            "Known pre-existing failures and lint violations "
+            f"as of {now}. The orchestrator uses this to "
+            "distinguish new regressions from baseline noise. "
+            "Update by running: uv run harness update-baseline"
+        ),
+        "_generated_from": "pytest -q --tb=no + ruff check --output-format json",
+        "test_failures": sorted(test_report.failed_tests),
+        "lint_violations": lint_violations,
+        "lint_summary": lint_summary,
+    }
+
+    BASELINE_PATH.write_text(json.dumps(baseline, indent=2) + "\n")
+    click.echo(f"Baseline written to {BASELINE_PATH}")
 
 
 @cli.command()

--- a/harness/orchestrator.py
+++ b/harness/orchestrator.py
@@ -194,11 +194,6 @@ def update_baseline_cmd(test_timeout: int, lint_timeout: int) -> None:
 @click.argument("issue_number", type=int)
 @click.option("--max-attempts", default=3, help="Max coder/reviewer cycles.")
 @click.option(
-    "--skip-approval",
-    is_flag=True,
-    help="Skip human plan approval gate.",
-)
-@click.option(
     "--log-dir",
     type=click.Path(path_type=Path),
     default=Path(__file__).parent / ".logs",
@@ -208,7 +203,6 @@ def run(
     issue_number: int,
     max_attempts: int,
     *,
-    skip_approval: bool,
     log_dir: Path,
 ) -> None:
     """Run the full agent pipeline for a GitHub issue."""
@@ -220,7 +214,6 @@ def run(
             repo,
             issue_number,
             max_attempts=max_attempts,
-            skip_approval=skip_approval,
             log_dir=log_dir,
         )
     except KeyboardInterrupt:
@@ -237,7 +230,6 @@ def _run_pipeline(
     issue_number: int,
     *,
     max_attempts: int,
-    skip_approval: bool,
     log_dir: Path,
 ) -> None:
     """Execute the Planner -> Coder -> CI -> Review pipeline."""
@@ -246,7 +238,7 @@ def _run_pipeline(
     if plan is None:
         return
 
-    if not skip_approval and not _gate_human_approval(plan):
+    if not _gate_human_approval(plan):
         _fail(
             repo,
             issue_number,

--- a/harness/prompts/coder.md
+++ b/harness/prompts/coder.md
@@ -10,7 +10,7 @@ Your job is to execute an implementation plan by writing code and tests, then co
 
 ## Instructions
 
-1. Read the CLAUDE.md file for project conventions before writing any code.
+1. Read `harness/prompts/conventions.md` for project conventions before writing any code.
 2. Execute each step in the plan sequentially.
 3. Follow all coding conventions:
    - Plain function tests (no `class Test*` pattern)

--- a/harness/prompts/conventions.md
+++ b/harness/prompts/conventions.md
@@ -1,0 +1,61 @@
+# Agent Conventions
+
+Rules in this file are consumed by the agent harness (Planner, Coder, Reviewer).
+
+## File Mapping
+
+When a change touches one domain, the affected files follow this pattern:
+
+- Model changes → `blueflow/models/<model>.py`
+- View changes → `blueflow/views/<view>.py`
+- Serializer changes → `blueflow/serializers/<serializer>.py`
+- Test for any file `blueflow/<module>/foo.py` → `blueflow/tests/test_<module>_foo.py`
+
+## Commit Rules
+
+- Never commit to `develop` or `main` — always branch first
+- Branch prefix must match classification: `feature/`, `bug/`, `chore/`
+- No co-author lines in commit messages
+
+## Test Rules
+
+- Plain functions only — no `class Test*`
+- Use fixtures from conftest; never instantiate `APIClient` directly
+- Use `force_authenticate`, not session/cookie auth
+- `_` for unused unpacked variables (not `dummy` or `_dummy`)
+- No `from __future__ import annotations`
+- Known baseline failures exist (~88 tests) — do not treat as regressions
+
+## Do Not Modify
+
+These paths require human review and must not be changed by agents:
+
+- `blueflow/migrations/` — never edit migration files directly
+- `project/settings/` — settings changes require human review
+- `conftest.py` (root) — shared test infrastructure; changes affect all tests
+- Any file outside `blueflow/` and `tests/` without explicit plan approval
+
+## Validation Commands
+
+Run all of these before opening a PR:
+
+```bash
+uv run ruff check .              # Must exit 0
+uv run ruff format --check .     # Must exit 0
+DJANGO_SETTINGS_MODULE=project.settings.test uv run pytest <changed_test_files> -v  # No new failures
+```
+
+## Common Sensor Failures
+
+| Ruff Code | Meaning | Fix |
+|---|---|---|
+| `S101` | `assert` used outside tests | Move to a test file or use a conditional `raise` |
+| `N802` | Function name not lowercase | Rename the function and update all call sites |
+| `ERA001` | Commented-out code | Delete the dead code |
+| `ARG001` | Unused function argument | Prefix with `_` or remove if safe |
+| `F821` | Undefined name | Add the missing import or define the variable |
+
+| Test Error | Meaning | Fix |
+|---|---|---|
+| `waffle switch "core" not active` | Test hit an API without the waffle switch | Use a client fixture (`auth_client`, etc.) — they auto-enable the switch |
+| `relation "X" does not exist` | Missing migration or wrong DB state | Run `pytest --create-db` to rebuild, or check migration dependencies |

--- a/harness/prompts/planner.md
+++ b/harness/prompts/planner.md
@@ -10,7 +10,7 @@ The following GitHub issue needs to be resolved:
 
 ## Instructions
 
-1. Read the CLAUDE.md file for project conventions and architecture.
+1. Read `harness/prompts/conventions.md` for project conventions and file mapping rules.
 2. Cross-reference the issue against the current state of the codebase.
 3. Identify all files that need to be modified or created.
 4. Classify the ticket type (feature, bug, or chore).


### PR DESCRIPTION
## Summary
- Add `harness/prompts/conventions.md` with structured agent rules: file mapping, commit rules, test rules, scope boundaries, validation commands, and common sensor failure guides
- Update planner and coder prompts to reference `conventions.md` instead of the gitignored `CLAUDE.md`
- Add `harness update-baseline` CLI command to regenerate `baseline.json` from current pytest and ruff output
- Remove `--skip-approval` flag so every plan requires human approval before the coder proceeds

## Test plan
- [x] Verify `conventions.md` content matches project conventions in CLAUDE.md
- [x] Confirm planner and coder prompts reference the new file path
- [ ] Run `uv run harness update-baseline` to verify baseline regeneration
- [ ] Run harness against a test issue to validate agents read conventions correctly