### PR TITLE
fix: detect CI step failures via check-run annotations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
+      # TODO: Remove continue-on-error once baseline lint violations
+      # (~764 as of 2026-04-15) are resolved. The agent harness
+      # detects the actual failure via check-run annotations.
       - name: Check linting
         continue-on-error: true
         run: uv run ruff check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,10 @@ jobs:
       # to just FAILED lines + summary, which the agent harness
       # parses directly. pytest-json-report is incompatible with
       # xdist (WSGIRequest serialization crashes workers).
+      #
+      # TODO: Remove continue-on-error once baseline test failures
+      # (~88 as of 2026-04-15) are resolved. The agent harness
+      # detects the actual failure via check-run annotations.
       - name: Run tests
         continue-on-error: true
         run: uv run pytest -n auto --tb=no -q --no-header -ra

--- a/harness/agents.py
+++ b/harness/agents.py
@@ -129,9 +129,10 @@ def run_coder(
     """Invoke the Coder agent to implement the plan."""
     template = load_prompt("coder")
     feedback_section = f"\n\n## Reviewer Feedback\n{feedback}" if feedback else ""
-    prompt = template.replace("{plan}", plan_json).replace(
-        "{feedback_section}",
-        feedback_section,
+    prompt = (
+        template.replace("{plan}", plan_json)
+        .replace("{branch_name}", branch_name)
+        .replace("{feedback_section}", feedback_section)
     )
 
     cmd = [

--- a/harness/baseline.json
+++ b/harness/baseline.json
@@ -1,6 +1,6 @@
 {
   "_description": "Known pre-existing failures and lint violations as of 2026-04-15. The orchestrator uses this to distinguish new regressions from baseline noise. Update by running: uv run harness update-baseline",
-  "_generated_from": "pytest-json-report + ruff check --output-format json",
+  "_generated_from": "pytest -q --tb=no -ra + ruff check --output-format json",
   "test_failures": [
     "blueflow/tests/test_api_docs.py::test_get_api_schema",
     "blueflow/tests/test_asset.py::test_api_create_asset",

--- a/harness/ci.py
+++ b/harness/ci.py
@@ -84,21 +84,60 @@ def wait_for_ci(repo: str, branch: str) -> int:
 
 
 def get_ci_status(repo: str, run_id: int) -> bool:
-    """Check if a CI run passed. Returns True if successful."""
+    """Check if a CI run's steps actually passed.
+
+    Our CI workflows use ``continue-on-error: true`` to avoid
+    hard-failing on pre-existing baseline lint/test issues.  This
+    means the run *conclusion* is always ``"success"``.  We detect
+    actual step failures by checking for **failure-level annotations**
+    on the check runs, which GitHub creates automatically when a
+    ``continue-on-error`` step exits non-zero.
+
+    TODO: Once baseline lint violations and test failures are resolved,
+    remove ``continue-on-error: true`` from the workflow YAML files
+    (.github/workflows/test.yml, .github/workflows/lint.yml) and
+    simplify this function back to:
+        return data.get("conclusion") == "success"
+    """
+    # Get jobs via the REST API — includes check_run_url for each job
     result = _run_gh(
         [
-            "run",
-            "view",
-            str(run_id),
-            "--repo",
-            repo,
-            "--json",
-            "conclusion",
+            "api",
+            f"repos/{repo}/actions/runs/{run_id}/jobs",
         ],
         check=True,
     )
     data = json.loads(result.stdout)
-    return data.get("conclusion") == "success"
+
+    for job in data.get("jobs", []):
+        check_run_url = job.get("check_run_url", "")
+        if not check_run_url:
+            continue
+        check_run_id = check_run_url.rstrip("/").rsplit("/", 1)[-1]
+
+        ann_result = _run_gh(
+            [
+                "api",
+                f"repos/{repo}/check-runs/{check_run_id}/annotations",
+            ],
+            check=False,
+        )
+        if ann_result.returncode != 0:
+            continue
+
+        annotations = json.loads(ann_result.stdout)
+        failures = [a for a in annotations if a.get("annotation_level") == "failure"]
+        if failures:
+            logger.info(
+                "CI run %d: %d failure annotation(s) from "
+                "continue-on-error step failures (job %s)",
+                run_id,
+                len(failures),
+                job.get("name", "?"),
+            )
+            return False
+
+    return True
 
 
 def get_failed_logs(repo: str, run_id: int) -> str:

--- a/harness/prompts/coder.md
+++ b/harness/prompts/coder.md
@@ -2,6 +2,20 @@ You are the Coder agent in the Blueflow agent harness.
 
 Your job is to execute an implementation plan by writing code and tests, then committing the changes.
 
+## Branch
+
+Create and switch to the branch before making any changes:
+
+```bash
+git checkout -b {branch_name} develop
+```
+
+If the branch already exists (e.g. on a retry), switch to it instead:
+
+```bash
+git checkout {branch_name}
+```
+
 ## Plan
 
 {plan}
@@ -10,17 +24,18 @@ Your job is to execute an implementation plan by writing code and tests, then co
 
 ## Instructions
 
-1. Read `harness/prompts/conventions.md` for project conventions before writing any code.
-2. Execute each step in the plan sequentially.
-3. Follow all coding conventions:
+1. Create or switch to the branch shown above.
+2. Read `harness/prompts/conventions.md` for project conventions before writing any code.
+3. Execute each step in the plan sequentially.
+4. Follow all coding conventions:
    - Plain function tests (no `class Test*` pattern)
    - Use `APIClient` with `force_authenticate` for API tests
    - Use `_` for unused unpacked variables
    - Do not use `from __future__ import annotations`
    - Prefix any debug prints with `[DEBUG]`
-4. After writing code, run `ruff check . --fix` and `ruff format .` to fix lint issues.
-5. Commit your changes with a descriptive message. Do not add co-author lines.
-6. Do not modify migration files, settings files, or root conftest.py.
+5. After writing code, run `ruff check . --fix` and `ruff format .` to fix lint issues.
+6. Commit your changes with a descriptive message. Do not add co-author lines.
+7. Do not modify migration files, settings files, or root conftest.py.
 
 ## Output
 


### PR DESCRIPTION
## Summary

- **CI status detection**: `get_ci_status()` now queries the GitHub Checks API for failure-level annotations instead of the run conclusion, which is always `"success"` due to `continue-on-error: true` on workflow steps. Validated against real runs (24480430975, 24480431026).
- **Coder branch creation**: Threads `branch_name` into the Coder agent prompt so it creates/switches to the correct feature branch instead of coding on whatever branch is checked out.
- **Baseline metadata**: Fixed stale `_generated_from` field in `baseline.json` to reflect the actual parser (`pytest -q --tb=no -ra`, not `pytest-json-report`).

## Test plan

- [ ] Run `uv run harness run <issue>` against a test issue and verify `get_ci_status()` returns `False` when steps fail with `continue-on-error`
- [ ] Verify the Coder agent creates the correct branch from the prompt
- [ ] Confirm CI workflows still run successfully with the added TODO comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI status detection to use check-run annotations for improved failure identification.
  * Added branch management workflow to agent instructions before code changes.
  * Added TODO comments in workflows for future cleanup of error handling configurations.
  * Updated baseline metadata for test and lint invocation tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->