### PR TITLE
fix: create draft PR before CI wait and poll for run

### DIFF
--- a/harness/ci.py
+++ b/harness/ci.py
@@ -4,11 +4,14 @@ import json
 import logging
 import re
 import subprocess
+import time
 from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
 
 CI_WATCH_TIMEOUT = 900  # 15 minutes max wait for CI
+CI_POLL_INTERVAL = 10  # seconds between polls when waiting for run to appear
+CI_POLL_MAX_WAIT = 120  # seconds to wait for a run to appear after push
 
 
 @dataclass
@@ -37,34 +40,54 @@ def _run_gh(
     )
 
 
+def _poll_for_run(repo: str, branch: str) -> int:
+    """Poll until a CI run appears for the branch, then return its ID."""
+    deadline = time.monotonic() + CI_POLL_MAX_WAIT
+
+    while True:
+        result = _run_gh(
+            [
+                "run",
+                "list",
+                "--repo",
+                repo,
+                "--branch",
+                branch,
+                "--limit",
+                "1",
+                "--json",
+                "databaseId,status",
+            ],
+            check=True,
+        )
+        runs = json.loads(result.stdout)
+        if runs:
+            return runs[0]["databaseId"]
+
+        if time.monotonic() >= deadline:
+            msg = f"No CI runs found for branch {branch} after {CI_POLL_MAX_WAIT}s"
+            raise RuntimeError(msg)
+
+        logger.info(
+            "No CI runs yet, retrying in %ds...",
+            CI_POLL_INTERVAL,
+        )
+        time.sleep(CI_POLL_INTERVAL)
+
+
 def wait_for_ci(repo: str, branch: str) -> int:
     """Wait for the latest CI run on a branch to complete.
 
     Returns the run ID.
+
+    GitHub Actions may take several seconds to register a workflow
+    run after a push, so this function polls until a run appears
+    (up to CI_POLL_MAX_WAIT seconds) before handing off to
+    ``gh run watch``.
     """
     logger.info("Waiting for CI on branch %s...", branch)
 
-    result = _run_gh(
-        [
-            "run",
-            "list",
-            "--repo",
-            repo,
-            "--branch",
-            branch,
-            "--limit",
-            "1",
-            "--json",
-            "databaseId,status",
-        ],
-        check=True,
-    )
-    runs = json.loads(result.stdout)
-    if not runs:
-        msg = f"No CI runs found for branch {branch}"
-        raise RuntimeError(msg)
-
-    run_id = runs[0]["databaseId"]
+    run_id = _poll_for_run(repo, branch)
     logger.info("Found CI run %d, waiting for completion...", run_id)
 
     _run_gh(

--- a/harness/orchestrator.py
+++ b/harness/orchestrator.py
@@ -56,6 +56,7 @@ class Verdict:
     reasons: list[str] = field(default_factory=list)
     ci_run_id: int | None = None
     findings: list[dict] = field(default_factory=list)
+    pr_url: str | None = None
 
 
 def _setup_logging(log_dir: Path, issue_number: int) -> None:
@@ -250,17 +251,18 @@ def _run_pipeline(
     branch_name = derive_branch_name(issue)
     logger.info("Branch: %s", branch_name)
 
-    approved = _phase_code_review_loop(
+    pr_url = _phase_code_review_loop(
         repo,
         issue_number,
+        issue,
         plan,
         branch_name=branch_name,
         max_attempts=max_attempts,
         log_dir=log_dir,
     )
 
-    if approved:
-        _phase_open_pr(repo, issue_number, issue, plan, branch_name)
+    if pr_url:
+        _phase_approve_pr(repo, issue_number, pr_url)
 
 
 def _phase_fetch(repo: str, issue_number: int) -> dict:
@@ -316,16 +318,18 @@ def _gate_human_approval(plan: dict) -> bool:
 def _phase_code_review_loop(
     repo: str,
     issue_number: int,
+    issue: dict,
     plan: dict,
     *,
     branch_name: str,
     max_attempts: int,
     log_dir: Path,
-) -> bool:
-    """Run the Coder/CI/Review loop. Returns True if approved."""
+) -> str | None:
+    """Run the Coder/CI/Review loop. Returns the PR URL if approved."""
     plan_json = json.dumps(plan, indent=2)
     feedback: str | None = None
     cwd = str(Path.cwd())
+    pr_url: str | None = None
 
     for attempt in range(1, max_attempts + 1):
         logger.info("=== Attempt %d/%d ===", attempt, max_attempts)
@@ -334,6 +338,8 @@ def _phase_code_review_loop(
         verdict = _single_attempt(
             repo,
             issue_number,
+            issue,
+            plan,
             plan_json,
             branch_name=branch_name,
             attempt=attempt,
@@ -343,8 +349,11 @@ def _phase_code_review_loop(
             log_dir=log_dir,
         )
 
+        if verdict.pr_url:
+            pr_url = verdict.pr_url
+
         if verdict.approved:
-            return True
+            return pr_url
 
         feedback = "\n".join(verdict.reasons)
         if verdict.findings:
@@ -375,14 +384,16 @@ def _phase_code_review_loop(
                 f"attempts.\n\nLast feedback:\n{feedback}"
             )
             comment_on_issue(repo, issue_number, msg)
-            return False
+            return None
 
-    return False
+    return None
 
 
 def _single_attempt(
     repo: str,
     issue_number: int,
+    issue: dict,
+    plan: dict,
     plan_json: str,
     *,
     branch_name: str,
@@ -419,9 +430,19 @@ def _single_attempt(
         "PASS" if lint_result.passed else "FAIL",
     )
 
-    # --- Push + CI ---
+    # --- Push + draft PR (first attempt) + CI ---
     logger.info("Pushing branch %s...", branch_name)
     push_branch(cwd, branch_name)
+
+    # Open the draft PR before waiting for CI so that the
+    # pull_request event triggers the workflow. On retries the
+    # PR already exists and new pushes fire the synchronize event.
+    pr_url: str | None = None
+    if attempt == 1:
+        logger.info("Creating draft PR to trigger CI...")
+        pr_url = create_draft_pr(repo, branch_name, issue, plan)
+        logger.info("Draft PR: %s", pr_url)
+
     transition(
         repo,
         issue_number,
@@ -475,13 +496,15 @@ def _single_attempt(
     )
 
     # --- Assemble verdict (deterministic) ---
-    return _assemble_verdict(
+    verdict = _assemble_verdict(
         lint_result=lint_result,
         test_report=test_report,
         ci_passed=ci_passed,
         ci_run_id=run_id,
         findings=review_result.findings,
     )
+    verdict.pr_url = pr_url
+    return verdict
 
 
 def _get_ci_log(repo: str, run_id: int) -> str:
@@ -567,16 +590,13 @@ def _assemble_verdict(
     )
 
 
-def _phase_open_pr(
+def _phase_approve_pr(
     repo: str,
     issue_number: int,
-    issue: dict,
-    plan: dict,
-    branch_name: str,
+    pr_url: str,
 ) -> None:
-    """Open a draft PR (branch already pushed during CI phase)."""
-    logger.info("Creating draft PR...")
-    pr_url = create_draft_pr(repo, branch_name, issue, plan)
+    """Mark the draft PR as approved by the agent pipeline."""
+    logger.info("Pipeline approved — PR ready for human review.")
     transition(
         repo,
         issue_number,
@@ -586,11 +606,10 @@ def _phase_open_pr(
     comment_on_issue(
         repo,
         issue_number,
-        f"Draft PR created: {pr_url}",
+        f"Agent pipeline approved. Draft PR ready for review: {pr_url}",
     )
 
-    logger.info("Draft PR: %s", pr_url)
-    click.echo(f"\nDraft PR created: {pr_url}")
+    click.echo(f"\nDraft PR ready for review: {pr_url}")
 
 
 def _fail(


### PR DESCRIPTION
## Summary

- **Draft PR before CI wait**: CI workflows trigger on `pull_request` events, not branch pushes. The orchestrator now creates the draft PR immediately after the first push so the workflow fires. On retry attempts, new pushes trigger the `synchronize` event on the existing PR.
- **Poll for CI run**: `wait_for_ci()` now polls for up to 120s (at 10s intervals) for a GitHub Actions run to appear, instead of failing immediately with a `RuntimeError` when the run hasn't registered yet.
- **Pipeline restructure**: `_phase_open_pr` replaced with `_phase_approve_pr` — the PR already exists by the time the verdict is reached, so approval just transitions labels and comments.

## Context

Hit during a live `harness run` on issue #65 — the push completed but no CI runs existed because workflows only trigger on `pull_request`, not arbitrary branch pushes.

## Test plan

- [ ] Run `uv run harness run <issue>` end-to-end and verify the draft PR is created before CI wait
- [ ] Confirm CI triggers on the draft PR (check GitHub Actions tab)
- [ ] Verify retry attempts push new commits to the existing PR without creating duplicates
- [ ] Confirm `_phase_approve_pr` transitions labels and comments on the issue after approval