### PR TITLE
decision: keep or remove get_risk_factor and related dead code

### DIFF
--- a/blueflow/models/asset.py
+++ b/blueflow/models/asset.py
@@ -4,7 +4,6 @@ Note: AssetManager has been moved to its own file asset_manager.py.
 """
 
 import logging
-import math
 from collections import Counter
 from functools import reduce
 from operator import or_
@@ -14,7 +13,7 @@ import netaddr
 import packaging.version
 from django.apps import apps
 from django.core.exceptions import ValidationError
-from django.db import models, transaction
+from django.db import models
 from django.db.models import Count, Max, Q
 from django.utils import timezone
 from netfields import InetAddressField, MACAddressField
@@ -95,8 +94,6 @@ class Asset(models.Model):
     # note: Asset.custom_fields defined in AssetCustomField class
     # note: Asset.asset_tags defined in AssetTag class
     # note: Asset.asset_vulnerabilities defined in AssetVulnerability class
-    # note: Asset.asset_risk_factors defined in AssetRiskFactor class
-
     history = HistoricalRecords()
 
     # Our manager is a meld of AssetManager and the methods from AssetQuerySet
@@ -365,59 +362,6 @@ class Asset(models.Model):
         qset = qset.order_by("-history_date")
         return qset
 
-    def get_risk_factor(self, shortname):
-        """Fetch an asset risk factor.
-
-        Returns None if there is no such risk factor or this asset does not
-        have the given risk factor associated with it (via AssetRiskFactor).
-        """
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Get risk factor is not implemented")
-        # TODO(legacy): #65 — this function is only used in tests and in
-        #   `remove_risk_factor`.  Consider removing it altogether...?
-        #   TBH, even remove_risk_factor could/should be removed, it's
-        #   only used in this file to remove cvss_max and cvss_sum.
-        try:
-            rfac = RiskFactor.objects.get(shortname=shortname)
-            return AssetRiskFactor.objects.get(asset=self, risk_factor=rfac)
-        except (RiskFactor.DoesNotExist, AssetRiskFactor.DoesNotExist):
-            return None
-
-    def add_risk_factor(self, shortname, value, reason=None):
-        """Add or replace a risk score factor for this Asset."""
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Add risk factor is not implemented")
-        # Get RiskFactor object using either 'asset_risk_factor__*' notation
-        # or the human-readable name.
-        try:
-            rfac = RiskFactor.objects.get(shortname=shortname)
-        except RiskFactor.DoesNotExist:
-            raise RiskFactor.DoesNotExist(
-                f"Cannot add unknown risk factor {shortname} to asset {self}",
-            )
-
-        # Create or update the AssetRiskFactor object
-        arf, _ = self.asset_risk_factors.update_or_create(
-            asset=self,
-            risk_factor=rfac,
-            defaults={
-                "value": value,
-                "provenance": reason,
-            },
-        )
-        if reason is not None:
-            hist_utils.update_change_reason(arf, reason)
-
-    def remove_risk_factor(self, shortname, reason=None):
-        """Remove a risk score factor from this Asset."""
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Remove risk factor is not implemented")
-        arf = self.get_risk_factor(shortname)
-        if arf is not None:
-            arf.delete()
-            if reason is not None:
-                hist_utils.update_change_reason(arf, reason)
-
     def update_or_create_fk_field(self, name, value, reason=None):
         """Update or create a foreign key field with '__' notation.
 
@@ -497,189 +441,6 @@ class Asset(models.Model):
                 hist_utils.update_change_reason(arf, reason)
         else:
             assert False, f"Unsupported foreign key: '{asset_field}'"
-
-    @staticmethod
-    def _soft_clip(x, rmax=10, rmin=0, a=1, typ="arctan"):
-        """Limit input argument x to [0, rmax).
-
-        Domain of x is supposed to be [0, ∞).
-
-        If supplied x < 0, then the output is undefined (and may raise
-        exceptions).
-
-        There are 2 types: 'arctan' and 'inv_x'.  Se code for specific
-        definition.  Either takes an argument `a` which determines the
-        slope.
-        """
-        assert rmin == 0, "Not set up to handle rmin != 0"
-
-        x = x / rmax
-        if typ == "arctan":
-            clipped = math.atan(a * x) / (math.pi / 2)
-        elif typ == "inv_x":
-            clipped = 1 - (1 / ((a * x) + 1))
-        else:
-            raise ValueError(f"'typ' must be 'arctan' or 'inv_x'; was {typ}")
-        return clipped * rmax
-
-    def _update_cvss_risk(self):
-        """Update the cvss risk factors from associated vulnerabilities."""
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Update cvss risk is not implemented")
-        # cvss scores from vulnerabilities hanging off this (may be empty)
-        vuln_scores = [
-            av.vulnerability.cvss_score
-            for av in self.asset_vulnerabilities.open()
-            if av.vulnerability.cvss_score is not None
-        ]
-
-        if vuln_scores:
-            self.add_risk_factor("cvss_max", max(vuln_scores))
-            self.add_risk_factor("cvss_sum", self._soft_clip(sum(vuln_scores)))
-        else:
-            self.remove_risk_factor("cvss_max")
-            self.remove_risk_factor("cvss_sum")
-
-    def _update_patch_risk(self):
-        """Update the patch risk AssetRiskFactor using needs_sw_update()."""
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Update patch risk is not implemented")
-        needs_update, _dummy, _dummy2 = self.needs_sw_update()
-        if needs_update:
-            self.add_risk_factor("needs_patch", 1.0)
-        else:
-            self.remove_risk_factor("needs_patch")
-
-    def asset_risk_factors_with_zeros(self):
-        """Return a list of AssetRiskFactor's, including those with zero value.
-
-        All risk factors are included.  If an AssetRiskFactor is associated
-        with this asset, use that.  Otherwise, create a dummy AssetRiskFactor
-        object, automatically initialized with a default value.  This dummy
-        object is not saved to the database.  We need the dummy objects
-        for things like inverted risky tags.  If a tag is *not present*,
-        that contributes a non-zero value to the risk score.
-        """
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Asset risk factors with zeros is not implemented")
-        factors = []
-        for risk_factor in RiskFactor.enabled.all():
-            try:
-                arf = self.asset_risk_factors.get(
-                    risk_factor_id=risk_factor.id,
-                )
-            except AssetRiskFactor.DoesNotExist:
-                arf = AssetRiskFactor(asset=self, risk_factor=risk_factor)
-            factors.append(arf)
-        return factors
-
-    # Protect this asset's risk-scoring ingredients from changes to RiskFactors
-    # that happen during global rescore. This scenario arises when, for
-    # instance, the user has just saved risk factor weights and then
-    # decides to delete a tag.
-    @transaction.atomic
-    def _calculate_risk(self):
-        """Calculate aggregate risk score for an asset."""
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Calculate risk is not implemented")
-
-    def risk_score_summary(self):
-        """Return summary only (to avoid 'protected access')."""
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Risk score summary is not implemented")
-        _dummy_rft_scores, summary = self._calculate_risk()
-        return summary
-
-    def rescore(self, reason="Rescore", save_reason=True):
-        """Update the risk_score field with a newly calculated score."""
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Rescore is not implemented")
-        self._update_cvss_risk()
-        self._update_patch_risk()
-        rft_scores, summary = self._calculate_risk()
-
-        # Get our total remediable score
-        risk_score_remediable = 0
-        for risk_factor in summary:
-            if risk_factor["user_remediable"] == "True":
-                risk_score_remediable += risk_factor["contribution_raw"] / 2
-
-        need_to_save = False
-        if self.risk_score != rft_scores["total_risk_score"]:
-            self.risk_score = rft_scores["total_risk_score"]
-            need_to_save = True
-        if self.risk_score_cli != rft_scores["cli"]:
-            self.risk_score_cli = rft_scores["cli"]
-            need_to_save = True
-        if self.risk_score_sec != rft_scores["sec"]:
-            self.risk_score_sec = rft_scores["sec"]
-            need_to_save = True
-        if self.risk_score_pri != rft_scores["pri"]:
-            self.risk_score_pri = rft_scores["pri"]
-            need_to_save = True
-        if self.risk_score_likelihood != rft_scores["likelihood"]:
-            self.risk_score_likelihood = rft_scores["likelihood"]
-            need_to_save = True
-        if self.risk_score_impact != rft_scores["impact"]:
-            self.risk_score_impact = rft_scores["impact"]
-            need_to_save = True
-        if self.risk_score_remediable != risk_score_remediable:
-            self.risk_score_remediable = risk_score_remediable
-            need_to_save = True
-
-        if need_to_save:
-            self.save()
-            if save_reason:
-                hist_utils.update_change_reason(self, reason)
-
-        return summary
-
-    @classmethod
-    def rescore_asset_on_save(
-        cls, sender, instance, created, raw, using, update_fields, *args, **kwargs
-    ):
-        """Rescore an asset via a Django signal."""
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Rescore asset on save is not implemented")
-        # Don't rescore if we're loading a fixture (i.e., we're in "raw" mode)
-        if raw:
-            logger.debug("Raw Asset (id %s), not rescoring", instance.id)
-            return
-
-        # Rescore if asset was created or if app_sw_version changed.  Also
-        # rescore similar assets.
-        #
-        # NOTE: unfortunately, update_fields doesn't appear to be used.  Its
-        # value seems to be None all the time, which indicates "save them all"
-        # Thus, we rescore() if an app_sw_version is present.  In a perfect
-        # world, we'd rescore only if app_sw_version changed.
-        #
-        # NOTE: We could get a cycle, where updating an asset causing an update
-        # to similar assets, which in turn causes an update to the original
-        # asset, ad infinitum.  I add an attribute "norecurse" to break this
-        # cycle.  It's kind of a hack, basically marking assets as "visited"
-        # which is a base case in the BFS.
-        if created or instance.app_sw_version:
-            logger.debug("rescoring after Asset save %s", instance)
-            instance.rescore(save_reason=False)
-            if getattr(instance, "norecurse", None):
-                # HACK break cycle
-                return
-            for asset in instance.similar_qset():
-                logger.debug("rescoring similar asset %s", asset)
-                asset.norecurse = True  # HACK break cycle
-                asset.rescore(reason="Rescore similar assets")
-
-    @staticmethod
-    def rescore_asset_on_delete(sender, instance, using, *args, **kwargs):
-        """Rescore an asset via a Django signal."""
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Rescore asset on delete is not implemented")
-        # Rescore similar assets if the deleted asset had a sw version
-        if instance.app_sw_version:
-            for asset in instance.similar_qset():
-                logger.debug("rescoring similar asset after delete %s", asset)
-                asset.rescore()
 
     @staticmethod
     def is_valid_field_name(name):

--- a/blueflow/models/asset_manager.py
+++ b/blueflow/models/asset_manager.py
@@ -4,8 +4,6 @@ To accompany the model Asset in asset.py (in this folder).
 """
 
 import logging
-import statistics
-from collections import defaultdict
 from functools import reduce
 from operator import or_
 
@@ -13,7 +11,6 @@ from django.apps import apps
 from django.core.exceptions import FieldError, ValidationError
 from django.db import models
 from django.db.models import Q
-from django.db.models.functions import Coalesce
 
 from blueflow.utils import Created
 
@@ -24,39 +21,6 @@ logger = logging.getLogger(__name__)
 
 class AssetManager(models.Manager):
     """Custom manager to query for assets not belonging to a network."""
-
-    def rescore_all(self):
-        """Rescore all assets."""
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Rescore all is not implemented")
-        RiskFactor = apps.get_model("blueflow", "RiskFactor")
-        RiskFactor.objects.normalize_weights()  # Abundance of caution
-        remediable_risk_sum = defaultdict(int)
-        remediable_asset_count = defaultdict(int)
-        summaries = [asset.rescore() for asset in self.get_queryset().all()]
-        # Iterate over all the summaries
-        # Eng desc of why and what do
-        for summary in summaries:
-            # Iterate over their entries
-            # Eng desc of why and what do
-            for entry in summary:
-                # Check to see if this stuff is remediable
-                if entry["user_remediable"] == "True" and entry["contribution_raw"] > 0:
-                    rf_id = entry["rf_id"]
-                    # Update the scores
-                    # Note: We divide by 2 to get the TOTAL contribution,
-                    # rather than just the contribution to cli or sec
-                    remediable_risk_sum[rf_id] += entry["contribution_raw"] / 2
-                    # Update the number of remediable assets
-                    remediable_asset_count[rf_id] += 1
-        # We now have the user_remediable information
-        # Now, we just need to update it in risk factor
-        RiskFactor = apps.get_model("blueflow", "RiskFactor")
-        for key in remediable_risk_sum:
-            rf = RiskFactor.objects.get(id=key)
-            rf.remediable_asset_count = remediable_asset_count[key]
-            rf.remediable_risk_sum = remediable_risk_sum[key]
-            rf.save()
 
     def get_by_priority(self, **kwargs):
         """Get an Asset, checking kwargs in priority order and ignoring the rest.
@@ -330,141 +294,6 @@ class AssetQuerySet(models.QuerySet):
             "pct": pct,
             "not_pct": not_pct,
         }
-
-    def risk_histogram(self):
-        """Return a 'risk histogram'.
-
-        Return a dictionary containing the number of assets in 6 categories:
-         - null risk associated (risk_score == null)
-         - zero/no risk (risk_score == 0)
-         - low (< 0.4)
-         - med (< 0.7)
-         - high (< 0.9)
-         - critical (>= 0.9)
-
-        The first 2 are awkwardly named; this is due to poor naming of
-        the fields in the model RiskMetrics.
-        """
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Risk histogram is not implemented")
-        h = {
-            "critical": self.filter(risk_score__gte=CRITICAL_RISK_LIMIT).count(),
-            "high": self.filter(
-                risk_score__lt=CRITICAL_RISK_LIMIT, risk_score__gte=HIGH_RISK_LIMIT
-            ).count(),
-            "med": self.filter(
-                risk_score__lt=HIGH_RISK_LIMIT, risk_score__gte=MED_RISK_LIMIT
-            ).count(),
-            "low": self.filter(risk_score__lt=MED_RISK_LIMIT, risk_score__gt=0.0).count(),
-            "no": self.filter(risk_score=0.0).count(),
-            # null=self.filter(risk_score__isnull=True).count(),
-        }
-        total_count = sum(h.values())
-        if total_count != self.filter(risk_score__isnull=False).count():
-            logger.error(
-                "Unexpected count when calculating histogram.  "
-                "Was '%d', expected '%d'.",
-                total_count,
-                self.count(),
-            )
-        return h
-
-    def risk_statistics(self):
-        """Return some risk statistics.
-
-        Return a dictionary with the following risk score statistics for
-        the assets contained in the queryset:
-         - sum
-         - mean
-         - median
-         - max
-         - min
-         - cli_sum   # sum of safety risk scores
-         - cli_mean
-         - sec_sum   # sum of security risk scores
-         - sec_mean
-        """
-        # Implementation note 1: Since there's no models.Median aggregate
-        #   function, we have to loop over the list of assets and obtain
-        #   their risk scores in order to use statistics.median.
-        #
-        #   Since we're already looping, it might be that it's more
-        #   efficient to use regular statistics and python functions to
-        #   obtain the other stats as well.
-        #
-        # Implementeation note 2: Choosing not to return `mode`, because
-        #   it's not obvious what to do when there's no unique mode
-        #   (statistics.mode will raise a StatisticsError).
-        #   (Also because, who other than statistics nerds would even care.)
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Risk statistics is not implemented")
-        notnull = self.filter(risk_score__isnull=False)
-        if notnull.count() == 0:
-            median = None
-        else:
-            median = statistics.median(a.risk_score for a in notnull)
-        s = {
-            "sum": self.aggregate(models.Sum("risk_score"))["risk_score__sum"],
-            "mean": self.aggregate(models.Avg("risk_score"))["risk_score__avg"],
-            "max": self.aggregate(models.Max("risk_score"))["risk_score__max"],
-            "min": self.aggregate(models.Min("risk_score"))["risk_score__min"],
-            "median": median,
-            "sec_sum": self.aggregate(val=Coalesce(models.Sum("risk_score_sec"), 0))[
-                "val"
-            ],
-            "sec_mean": self.aggregate(val=Coalesce(models.Avg("risk_score_sec"), 0))[
-                "val"
-            ],
-            "pri_sum": self.aggregate(val=Coalesce(models.Sum("risk_score_pri"), 0))[
-                "val"
-            ],
-            "pri_mean": self.aggregate(val=Coalesce(models.Avg("risk_score_pri"), 0))[
-                "val"
-            ],
-            "cli_sum": self.aggregate(val=Coalesce(models.Sum("risk_score_cli"), 0))[
-                "val"
-            ],
-            "cli_mean": self.aggregate(val=Coalesce(models.Avg("risk_score_cli"), 0))[
-                "val"
-            ],
-            "likelihood_sum": self.aggregate(
-                val=Coalesce(models.Sum("risk_score_likelihood"), 0)
-            )["val"],
-            "likelihood_mean": self.aggregate(
-                val=Coalesce(models.Avg("risk_score_likelihood"), 0)
-            )["val"],
-            "impact_sum": self.aggregate(
-                val=Coalesce(models.Sum("risk_score_impact"), 0)
-            )["val"],
-            "impact_mean": self.aggregate(
-                val=Coalesce(models.Avg("risk_score_impact"), 0)
-            )["val"],
-        }
-        return s
-
-    def risk_factor_statistics(self):
-        """Return some statistics on risk factors.
-
-        Return a list of lists that would be used for a histogram.  Each
-        element in the list represents a risk factor, and the data in
-        each list indicates how many assets have a certain risk factor.
-        """
-        # TODO(taylorcochran): Implement after we have a generalized algorithm for risk scoring
-        raise NotImplementedError("Risk factor statistics is not implemented")
-        rf_stats = []
-
-        RiskFactor = apps.get_model("blueflow", "RiskFactor")
-        for fac_type in ["sec", "pri", "cli"]:
-            rf_substats = []
-            for rf in RiskFactor.objects.filter(factor_type=fac_type):
-                rf_substats.append(rf.asset_risk_factor_statistics(self))
-                assert "num_affected" in rf_substats[-1]
-            rf_substats.sort(
-                key=lambda x: (x["weight"] > 0.0, x["num_affected"]), reverse=True
-            )
-            rf_stats.extend(rf_substats)
-
-        return rf_stats
 
     def _asset_vuln_query(self):
         """Queryset of asset_vulnerabilities attached to these assets."""

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -480,7 +480,6 @@ class AssetViewSet(
             "tag_number",
             "category",
             "date_added",
-            # TODO(taylorcochran): Add risk score filters
             "udi",
         ]
         context = super().get_renderer_context()
@@ -660,7 +659,6 @@ class AssetViewSet(
         # This stuff might not be necessary.  The DRF pagination system
         # might take care of it (since it's the same serializer etc.
         qset = self.get_object().similar_qset(exclude_self=exclude_self)
-        # TODO(taylorcochran): Add risk score ordering
         return self.paginate_relations(request, qset, "AssetSerializer")
 
     @action(detail=True, methods=["GET", "POST"])
@@ -778,7 +776,7 @@ class AssetViewSet(
     @action(detail=False)
     def summary(self, _request: Request) -> Response:
         """Return summary about an asset queryset."""
-        # TODO(taylorcochran): Implement summary
+        # TODO(taylorcochran): Implement summary  # noqa: TD003, FIX002
         _msg = "Summary is not implemented"
         raise NotImplementedError(_msg)
 

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -122,9 +122,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
     url = serializers.HyperlinkedIdentityField(view_name="blueflow:asset-detail")
     tags_url = serializers.HyperlinkedIdentityField(view_name="blueflow:asset-tags")
-    scans_url = serializers.HyperlinkedIdentityField(
-        view_name="blueflow:asset-scans"
-    )
+    scans_url = serializers.HyperlinkedIdentityField(view_name="blueflow:asset-scans")
     external_links_url = serializers.HyperlinkedIdentityField(
         view_name="blueflow:asset-external-links"
     )
@@ -278,14 +276,13 @@ class AssetFilter(django_filters.rest_framework.FilterSet):
     datetime_range = django_filters.DateTimeFromToRangeFilter(field_name="date_added")
     network = django_filters.NumberFilter(method="filter_network")
     no_network = drf_filters.BooleanFilter(method="filter_no_network")
-    unassessed = drf_filters.BooleanFilter(method="filter_unassessed")
-    assessed_factor = drf_filters.NumberFilter(method="filter_assessed_factor")
     group = django_filters.NumberFilter(field_name="groups")
     tag = django_filters.NumberFilter(field_name="tags")
     vulnerability = django_filters.NumberFilter(field_name="vulnerabilities__id")
     active_vulnerability = django_filters.NumberFilter(
         method="filter_active_vulnerability"
     )
+
     @staticmethod
     def filter_network(queryset: QuerySet, name: str, value: int) -> QuerySet:
         """Get assets that belong to a certain network."""
@@ -320,30 +317,6 @@ class AssetFilter(django_filters.rest_framework.FilterSet):
             asset_vulnerabilities__date_ignored__isnull=True,
         )
 
-    @staticmethod
-    def filter_unassessed(queryset: QuerySet, _name: str, _value: bool) -> QuerySet:  # noqa: FBT001
-        """Get assets that lack AssetRiskFactors.
-
-        Calling with value False is a silly double negative ("not unassessed").
-        """
-        # TODO(taylorcochran): Implement unassessed
-        _msg = "Unassessed is not implemented"
-        raise NotImplementedError(_msg)
-
-    @staticmethod
-    def filter_assessed_factor(queryset: QuerySet, _name: str, value: int) -> QuerySet:
-        """Get assets that have or lack a *particular* RiskFactor.
-
-        To find assets that *have* a particular RiskFactor n, query with
-        assessed_factor=n.
-
-        To find assets that *lack* a particular RiskFactor n, query with
-        assessed_factor=-n.
-        """
-        # TODO(taylorcochran): Implement assessed_factor
-        _msg = "Assessed factor is not implemented"
-        raise NotImplementedError(_msg)
-
     class Meta:
         """Wire this filter to a model."""
 
@@ -358,7 +331,6 @@ class AssetFilter(django_filters.rest_framework.FilterSet):
             "hostname": ["icontains"],
             "nic_vendor": ["icontains"],
             "category": ["icontains", "exact"],
-            # TODO(taylorcochran): Add risk score filters
             "id": ["in"],
             "ip_address": [
                 "istartswith",
@@ -395,7 +367,6 @@ class AssetFilter(django_filters.rest_framework.FilterSet):
             "asset_custom_fields__value_text": ["istartswith"],
             "asset_vulnerabilities__date_remediated": ["isnull"],
             "asset_vulnerabilities__date_ignored": ["isnull"],
-            # TODO(taylorcochran): Add asset_risk_factors filters
         }
         filter_overrides = {  # noqa: RUF012
             netfields.InetAddressField: {
@@ -431,8 +402,6 @@ class AssetViewSet(
     `/bulk_update` — PATCH a list of assets by id (partial updates)
     `/duplicate_ips`
     `/histogram`
-    `/risk_per_manufacturer`
-    `/riskiest`
     `/summary`
     `/upsert`
 
@@ -805,43 +774,6 @@ class AssetViewSet(
         if limit > 0:
             results = results[:limit]
         return Response(results)
-
-    @action(detail=False)
-    def risk_per_manufacturer(self, request: Request) -> Response:
-        """Calculate risk per manufacturer.
-
-        Sort into one bin per manufacturer, sum the risks in each bin,
-        and return the `limit` first ones + `others`.
-
-        Seems like this could be accomplished by something like
-
-              SELECT manufacturer, count(manufacturer), sum(risk_score)
-                FROM blueflow_asset
-               WHERE manufacturer IS NOT null
-            GROUP BY manufacturer
-            ORDER BY sum(risk_score) DESC;
-
-        This is basically what we're doing with the Django ORM code
-        below.  I.e., it becomes
-
-               SELECT "blueflow_asset"."manufacturer",
-                      COUNT("blueflow_asset"."manufacturer") AS "count",
-                      SUM("blueflow_asset"."risk_score") AS "risk_score"
-                 FROM "blueflow_asset"
-            WHERE NOT ("blueflow_asset"."manufacturer" IS NULL)
-             GROUP BY "blueflow_asset"."manufacturer"
-             ORDER BY "risk_score" DESC
-        """
-        # TODO(taylorcochran): Implement risk per manufacturer
-        _msg = "Risk per manufacturer is not implemented"
-        raise NotImplementedError(_msg)
-
-    @action(detail=False)
-    def riskiest(self, request: Request) -> Response:
-        """Produce a paginated list of the "riskiest" assets."""
-        # TODO(taylorcochran): Implement riskiest
-        _msg = "Riskiest is not implemented"
-        raise NotImplementedError(_msg)
 
     @action(detail=False)
     def summary(self, _request: Request) -> Response:


### PR DESCRIPTION
Resolves #65

## Plan
```json
{
  "type": "result",
  "subtype": "success",
  "is_error": false,
  "duration_ms": 216820,
  "duration_api_ms": 210039,
  "num_turns": 15,
  "result": "Now I have the complete picture. Here's the plan:\n\n{\"issue_number\":65,\"issue_title\":\"decision: keep or remove get_risk_factor and related dead code\",\"classification\":\"chore\",\"branch_name\":\"chore/65-remove-risk-scoring-dead-code\",\"affected_files\":[\"blueflow/models/asset.py\",\"blueflow/models/asset_manager.py\",\"blueflow/views/asset.py\"],\"new_files\":[],\"plan_steps\":[{\"step\":1,\"description\":\"Remove all risk-scoring instance methods from Asset: get_risk_factor (L368-384), add_risk_factor (L386-409), remove_risk_factor (L411-419), _soft_clip (L501-523), _update_cvss_risk (L525-541), _update_patch_risk (L543-551), asset_risk_factors_with_zeros (L553-574), _calculate_risk (L580-584), risk_score_summary (L586-591), rescore (L593-635), rescore_asset_on_save (L637-671), rescore_asset_on_delete (L673-682). Also remove the comment on L98 referencing AssetRiskFactor and the protective comment block on L576-579.\",\"file\":\"blueflow/models/asset.py\",\"rationale\":\"These methods all raise NotImplementedError immediately, making everything below the raise unreachable dead code. The decision on the issue is to nuke rather than keep stubs.\"},{\"step\":2,\"description\":\"Clean up now-unused imports in asset.py: remove `import math` (L7), remove `transaction` from `from django.db import models, transaction` (L17). Keep all other imports (Counter, reduce, or_ are used by live code like needs_sw_update and similar_qset).\",\"file\":\"blueflow/models/asset.py\",\"rationale\":\"math was only used in _soft_clip; transaction was only used as a decorator on _calculate_risk. Both methods are now removed.\"},{\"step\":3,\"description\":\"Remove rescore_all method (L28-59) from AssetManager. This leaves AssetManager with get_by_priority and update_or_create_by_priority as its remaining methods.\",\"file\":\"blueflow/models/asset_manager.py\",\"rationale\":\"rescore_all is listed in the issue and raises NotImplementedError with dead code below.\"},{\"step\":4,\"description\":\"Remove risk_histogram (L334-370), risk_statistics (L372-443), and risk_factor_statistics (L445-467) from AssetQuerySet.\",\"file\":\"blueflow/models/asset_manager.py\",\"rationale\":\"All three raise NotImplementedError with unreachable implementations. They form the queryset-level risk scoring surface.\"},{\"step\":5,\"description\":\"Clean up now-unused imports in asset_manager.py: remove `import statistics` (L2), remove `defaultdict` from `from collections import defaultdict` (L3), remove `Coalesce` from the django.db.models.functions import (L15). Keep reduce, or_, and all other imports.\",\"file\":\"blueflow/models/asset_manager.py\",\"rationale\":\"statistics was only used in risk_statistics; defaultdict only in rescore_all; Coalesce only in risk_statistics. All three methods are now removed.\"},{\"step\":6,\"description\":\"Remove filter_unassessed (L323-331) and filter_assessed_factor (L333-345) static methods from the AssetFilter class. Remove the TODO comment on L398 about asset_risk_factors filters. Remove the TODO comment on L361 about risk score filters.\",\"file\":\"blueflow/views/asset.py\",\"rationale\":\"Both filter methods reference AssetRiskFactors and raise NotImplementedError. The TODO comments reference risk scoring features that are being removed.\"},{\"step\":7,\"description\":\"Remove risk_per_manufacturer action (L809-837) and riskiest action (L839-844) from AssetViewSet. Update the class docstring (L434-435) to remove `/risk_per_manufacturer` and `/riskiest` from the listed endpoints.\",\"file\":\"blueflow/views/asset.py\",\"rationale\":\"Both actions raise NotImplementedError and are part of the risk scoring surface.\"},{\"step\":8,\"description\":\"Run `uv run ruff check blueflow/models/asset.py blueflow/models/asset_manager.py blueflow/views/asset.py` to verify no new lint errors. Run `uv run ruff format blueflow/models/asset.py blueflow/models/asset_manager.py blueflow/views/asset.py` to fix any formatting issues.\",\"file\":\"blueflow/models/asset.py\",\"rationale\":\"Validate that removal did not introduce lint or format violations.\"},{\"step\":9,\"description\":\"Run `DJANGO_SETTINGS_MODULE=project.settings.test uv run pytest blueflow/tests/test_history.py -v` to confirm TestAssetRiskHistory still passes (it only uses the risk_score model field, not the removed methods).\",\"file\":\"blueflow/tests/test_history.py\",\"rationale\":\"The risk history tests set risk_score directly and test the history API \u2014 they don't call any removed methods, so they should still pass.\"}],\"test_strategy\":\"1. Run ruff check and ruff format on all three modified files to confirm no lint/format violations. 2. Run the full test suite (`uv run pytest`) to confirm no regressions \u2014 the removed methods all raised NotImplementedError so nothing should have been calling them successfully. 3. Specifically run blueflow/tests/test_history.py to confirm risk history tests (which use the risk_score field directly) still pass. 4. Grep for any remaining references to removed method names (get_risk_factor, add_risk_factor, rescore_all, etc.) to ensure no dangling call sites.\",\"risks\":[\"update_or_create_fk_field (L421-499) also raises NotImplementedError and contains a risk_factors branch \u2014 it is NOT removed because it also handles asset_custom_fields and is not listed in the issue. This leaves a partially-dead method that should be addressed in a follow-up.\",\"is_valid_field_name and is_valid_field_value (L685-739) raise NotImplementedError and are called from blueflow/utils/fieldmap.py \u2014 they are not risk-scoring-specific so they are out of scope, but fieldmap.py is broken today because of these raises. Should be tracked separately.\",\"The summary view action (L846-851) also raises NotImplementedError but is not exclusively risk-related, so it is left in place.\",\"_partition_fk_params in asset_manager.py still handles asset_risk_factors__ prefixed params. Since RiskFactor/AssetRiskFactor models do not exist in this codebase, this code path would crash if exercised \u2014 but it is pre-existing and out of scope.\"],\"acceptance_criteria\":[\"All 12 listed Asset methods (get_risk_factor, add_risk_factor, remove_risk_factor, _update_cvss_risk, _update_patch_risk, asset_risk_factors_with_zeros, _calculate_risk, risk_score_summary, rescore, rescore_asset_on_save, rescore_asset_on_delete, _soft_clip) are removed from asset.py\",\"rescore_all is removed from AssetManager in asset_manager.py\",\"risk_histogram, risk_statistics, and risk_factor_statistics are removed from AssetQuerySet in asset_manager.py\",\"filter_unassessed, filter_assessed_factor, risk_per_manufacturer, and riskiest are removed from views/asset.py\",\"No new lint errors (ruff check exits 0)\",\"No new test failures beyond the known baseline (~88 pre-existing failures)\",\"Unused imports (math, transaction, statistics, defaultdict, Coalesce) are cleaned up\"],\"estimated_complexity\":\"medium\"}",
  "stop_reason": "end_turn",
  "session_id": "a4e8c678-2c85-42ad-ac12-1ebc3587d016",
  "total_cost_usd": 0.7453926,
  "usage": {
    "input_tokens": 8,
    "cache_creation_input_tokens": 44125,
    "cache_read_input_tokens": 169001,
    "output_tokens": 6771,
    "server_tool_use": {
      "web_search_requests": 0,
      "web_fetch_requests": 0
    },
    "service_tier": "standard",
    "cache_creation": {
      "ephemeral_1h_input_tokens": 44125,
      "ephemeral_5m_input_tokens": 0
    },
    "inference_geo": "",
    "iterations": [],
    "speed": "standard"
  },
  "modelUsage": {
    "claude-opus-4-6[1m]": {
      "inputTokens": 8,
      "outputTokens": 6771,
      "cacheReadInputTokens": 169001,
      "cacheCreationInputTokens": 44125,
      "webSearchRequests": 0,
      "costUSD": 0.52959675,
      "contextWindow": 1000000,
      "maxOutputTokens": 64000
    },
    "claude-haiku-4-5-20251001": {
      "inputTokens": 3738,
      "outputTokens": 7623,
      "cacheReadInputTokens": 785641,
      "cacheCreationInputTokens": 76303,
      "webSearchRequests": 0,
      "costUSD": 0.21579585,
      "contextWindow": 200000,
      "maxOutputTokens": 32000
    }
  },
  "permission_denials": [],
  "terminal_reason": "completed",
  "fast_mode_state": "off",
  "uuid": "aeecc0fd-0338-45a9-9cca-cc7f626f3a5e"
}
```