### PR TITLE
fix: lint short-circuit loop and pipeline failure output

### DIFF
--- a/harness/agents.py
+++ b/harness/agents.py
@@ -74,7 +74,7 @@ def load_prompt(name: str) -> str:
 def save_output(
     issue_number: int,
     agent: str,
-    attempt: int,
+    attempt: int | str,
     content: str,
     log_dir: Path = DEFAULT_LOG_DIR,
 ) -> Path:

--- a/harness/orchestrator.py
+++ b/harness/orchestrator.py
@@ -263,6 +263,13 @@ def _run_pipeline(
 
     if pr_url:
         _phase_approve_pr(repo, issue_number, pr_url)
+    else:
+        click.echo(
+            f"\nPipeline rejected after {max_attempts} attempt(s). "
+            f"See issue #{issue_number} for details.",
+            err=True,
+        )
+        sys.exit(1)
 
 
 def _phase_fetch(repo: str, issue_number: int) -> dict:
@@ -389,6 +396,75 @@ def _phase_code_review_loop(
     return None
 
 
+MAX_LINT_RETRIES = 2
+
+
+def _code_and_lint(
+    issue_number: int,
+    plan_json: str,
+    branch_name: str,
+    *,
+    attempt: int,
+    feedback: str | None,
+    cwd: str,
+    log_dir: Path,
+) -> SensorResult:
+    """Run the Coder then lint, retrying lint failures locally.
+
+    This inner loop gives the Coder fast feedback on lint issues
+    without burning a full CI round trip.  Lint retries do NOT
+    count toward the outer ``max_attempts`` limit.
+
+    Returns the final lint SensorResult (passed or not).
+    """
+    for lint_try in range(1 + MAX_LINT_RETRIES):
+        suffix = f" (lint retry {lint_try})" if lint_try > 0 else ""
+        logger.info(
+            "Starting Coder agent (attempt %d%s)...",
+            attempt,
+            suffix,
+        )
+        coder_result = run_coder(
+            plan_json,
+            branch_name,
+            feedback=feedback,
+            cwd=cwd,
+        )
+        save_output(
+            issue_number,
+            "coder",
+            attempt if lint_try == 0 else f"{attempt}-lint{lint_try}",
+            coder_result.raw_output,
+            log_dir,
+        )
+
+        changed_files = get_changed_files(cwd)
+        logger.info("Running lint on %d changed files...", len(changed_files))
+        lint_result = run_lint(cwd, changed_files=changed_files)
+        logger.info(
+            "Lint: %s",
+            "PASS" if lint_result.passed else "FAIL",
+        )
+
+        if lint_result.passed:
+            return lint_result
+
+        if lint_try < MAX_LINT_RETRIES:
+            logger.info(
+                "Lint failed — sending feedback to Coder "
+                "(fast retry %d/%d, no push/CI)...",
+                lint_try + 1,
+                MAX_LINT_RETRIES,
+            )
+            feedback = (
+                "Lint failed on your changes. Fix these issues "
+                "before proceeding:\n\n"
+                f"{lint_result.output[:1000]}"
+            )
+
+    return lint_result
+
+
 def _single_attempt(
     repo: str,
     issue_number: int,
@@ -404,31 +480,34 @@ def _single_attempt(
     log_dir: Path,
 ) -> Verdict:
     """Run one code + CI + review cycle. Returns a Verdict."""
-    # --- Code ---
+    # --- Code + lint inner loop ---
     transition(repo, issue_number, from_label, "agent-coding")
-    logger.info("Starting Coder agent (attempt %d)...", attempt)
-    coder_result = run_coder(
+    lint_result = _code_and_lint(
+        issue_number,
         plan_json,
         branch_name,
+        attempt=attempt,
         feedback=feedback,
         cwd=cwd,
-    )
-    save_output(
-        issue_number,
-        "coder",
-        attempt,
-        coder_result.raw_output,
-        log_dir,
+        log_dir=log_dir,
     )
 
-    # --- Local lint sensor (changed files only) ---
-    changed_files = get_changed_files(cwd)
-    logger.info("Running lint on %d changed files...", len(changed_files))
-    lint_result = run_lint(cwd, changed_files=changed_files)
-    logger.info(
-        "Lint: %s",
-        "PASS" if lint_result.passed else "FAIL",
-    )
+    if not lint_result.passed:
+        # Inner lint loop exhausted — reject without burning a
+        # full CI round trip. The attempt still counts because
+        # the Coder failed to produce clean code.
+        logger.warning(
+            "Lint still failing after %d retries, skipping CI/review.",
+            MAX_LINT_RETRIES,
+        )
+        return Verdict(
+            approved=False,
+            reasons=[
+                f"Lint failed after {MAX_LINT_RETRIES} "
+                f"fast retries (no push/CI):\n"
+                f"{lint_result.output[:500]}"
+            ],
+        )
 
     # --- Push + draft PR (first attempt) + CI ---
     logger.info("Pushing branch %s...", branch_name)


### PR DESCRIPTION
## Summary

- **Lint short-circuit loop**: When local lint fails after the Coder runs, the orchestrator now immediately feeds lint output back to the Coder for a fast retry (up to 2 retries) without pushing, waiting for CI, or running code review. Only full CI round trips count toward `max_attempts`.
- **Pipeline failure output**: When all attempts are exhausted, the orchestrator now prints a clear error message to stderr and exits with code 1, instead of silently exiting 0.

## How the two-tier retry works

```
Coder → lint FAIL → [fast retry: feed lint output back to Coder, no push]
                   → lint FAIL → [fast retry 2]
                               → lint FAIL → reject attempt (counts toward max_attempts)
                   → lint PASS → push → PR → CI → review → verdict
```

Log files for lint retries are saved as `coder-attempt-1-lint1.txt`, `coder-attempt-1-lint2.txt`, etc.

## Test plan

- [ ] Run `uv run harness run <issue>` where the Coder produces lint-dirty code — verify fast retries appear in the log before any push/CI
- [ ] Verify lint retry logs are saved with the `-lintN` suffix
- [ ] Exhaust all attempts and confirm non-zero exit code and error message