### PR TITLE
fix: CI log parsing and Coder stall detection

### DIFF
--- a/harness/agents.py
+++ b/harness/agents.py
@@ -5,6 +5,8 @@ import json
 import logging
 import re
 import subprocess
+import threading
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -16,6 +18,7 @@ DEFAULT_LOG_DIR = HARNESS_DIR / ".logs"
 
 PLANNER_TIMEOUT = 300
 CODER_TIMEOUT = 600
+CODER_STALL_TIMEOUT = 120  # kill if no stdout activity for this long
 CODE_REVIEW_TIMEOUT = 300
 LINT_TIMEOUT = 60
 
@@ -45,6 +48,17 @@ class SensorResult:
     passed: bool
     output: str
     details: dict = field(default_factory=dict)
+
+
+class AgentStalledError(Exception):
+    """Raised when an agent produces no output for too long."""
+
+    def __init__(self, agent: str, seconds: int, partial_output: str) -> None:
+        self.agent = agent
+        self.seconds = seconds
+        self.partial_output = partial_output
+        msg = f"{agent} stalled — no output for {seconds}s"
+        super().__init__(msg)
 
 
 def _recover_stdout(exc: subprocess.TimeoutExpired) -> str:
@@ -137,7 +151,13 @@ def run_coder(
     feedback: str | None = None,
     cwd: str | None = None,
 ) -> CoderResult:
-    """Invoke the Coder agent to implement the plan."""
+    """Invoke the Coder agent to implement the plan.
+
+    Uses Popen with a stall detector that kills the process if
+    no stdout activity is seen for CODER_STALL_TIMEOUT seconds.
+    Raises AgentStalled on stall so the orchestrator can leave
+    the branch as-is for human inspection.
+    """
     template = load_prompt("coder")
     feedback_section = f"\n\n## Reviewer Feedback\n{feedback}" if feedback else ""
     prompt = (
@@ -162,19 +182,20 @@ def run_coder(
         "10",
     ]
 
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=CODER_TIMEOUT,
-            cwd=cwd,
-            check=False,
+    raw, stalled = _run_with_stall_detection(
+        cmd,
+        cwd=cwd,
+        hard_timeout=CODER_TIMEOUT,
+        stall_timeout=CODER_STALL_TIMEOUT,
+    )
+
+    if stalled:
+        agent_name = "Coder"
+        raise AgentStalledError(
+            agent_name,
+            CODER_STALL_TIMEOUT,
+            raw,
         )
-    except subprocess.TimeoutExpired as exc:
-        logger.warning("Coder timed out after %ds", CODER_TIMEOUT)
-        raw = _recover_stdout(exc)
-        return CoderResult(raw_output=raw, branch=branch_name)
 
     branch_result = subprocess.run(
         ["git", "rev-parse", "--abbrev-ref", "HEAD"],
@@ -185,7 +206,66 @@ def run_coder(
     )
     branch = branch_result.stdout.strip() or branch_name
 
-    return CoderResult(raw_output=result.stdout, branch=branch)
+    return CoderResult(raw_output=raw, branch=branch)
+
+
+def _run_with_stall_detection(
+    cmd: list[str],
+    *,
+    cwd: str | None,
+    hard_timeout: int,
+    stall_timeout: int,
+) -> tuple[str, bool]:
+    """Run a subprocess, killing it if stdout goes silent.
+
+    Returns (captured_output, was_stalled).
+    """
+    chunks: list[str] = []
+    last_activity = time.monotonic()
+    stalled = False
+    lock = threading.Lock()
+
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=cwd,
+    )
+
+    def _reader() -> None:
+        nonlocal last_activity
+        for line in proc.stdout:
+            with lock:
+                chunks.append(line)
+                last_activity = time.monotonic()
+
+    reader = threading.Thread(target=_reader, daemon=True)
+    reader.start()
+
+    deadline = time.monotonic() + hard_timeout
+    while proc.poll() is None:
+        now = time.monotonic()
+        if now >= deadline:
+            logger.warning("Coder hard timeout after %ds", hard_timeout)
+            proc.terminate()
+            break
+        with lock:
+            idle = now - last_activity
+        if idle >= stall_timeout:
+            logger.warning(
+                "Coder stalled — no output for %ds, killing",
+                stall_timeout,
+            )
+            proc.terminate()
+            stalled = True
+            break
+        time.sleep(1)
+
+    reader.join(timeout=5)
+    with lock:
+        raw = "".join(chunks)
+    return raw, stalled
 
 
 def run_code_review(diff: str, plan_json: str) -> CodeReviewResult:

--- a/harness/ci.py
+++ b/harness/ci.py
@@ -191,6 +191,21 @@ def get_failed_logs(repo: str, run_id: int) -> str:
     return result.stdout
 
 
+_GH_LOG_PREFIX = re.compile(
+    r"^[^\t]+\t[^\t]+\t\d{4}-\d{2}-\d{2}T[\d:.]+Z\s?",
+)
+
+
+def _strip_gh_log_prefixes(output: str) -> str:
+    """Strip ``gh run view --log`` line prefixes.
+
+    Each line from ``gh run view --log`` is prefixed with
+    ``<job><tab><step><tab><ISO-timestamp>``.  This strips that
+    prefix so downstream parsers see raw pytest output.
+    """
+    return "\n".join(_GH_LOG_PREFIX.sub("", line) for line in output.splitlines())
+
+
 def parse_test_output(output: str) -> TestReport:
     """Parse pytest's -q --tb=no output into a TestReport.
 
@@ -199,10 +214,15 @@ def parse_test_output(output: str) -> TestReport:
         FAILED path/to/test.py::test_other - Error...
         68 failed, 249 passed, 4 skipped, 25 xfailed in 11.52s
 
+    Also handles ``gh run view --log`` output where each line
+    is prefixed with ``<job><tab><step><tab><timestamp>``.
+
     This replaces pytest-json-report, which is incompatible with
     pytest-xdist (xdist workers crash serializing Django WSGIRequest
     objects through execnet when tests fail).
     """
+    output = _strip_gh_log_prefixes(output)
+
     failed_tests = [
         match.group(1)
         for match in re.finditer(

--- a/harness/orchestrator.py
+++ b/harness/orchestrator.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import click
 
 from harness.agents import (
+    AgentStalledError,
     SensorResult,
     create_draft_pr,
     get_changed_files,
@@ -217,6 +218,23 @@ def run(
             max_attempts=max_attempts,
             log_dir=log_dir,
         )
+    except AgentStalledError as exc:
+        logger.warning(
+            "Agent stalled: %s. Branch left as-is for inspection.",
+            exc,
+        )
+        save_output(
+            issue_number,
+            "stall-dump",
+            1,
+            exc.partial_output,
+            log_dir,
+        )
+        click.echo(
+            f"\n{exc}\nBranch left as-is for inspection. Partial output saved to logs.",
+            err=True,
+        )
+        sys.exit(2)
     except KeyboardInterrupt:
         logger.info("Interrupted by user.")
         sys.exit(1)


### PR DESCRIPTION
## Summary

- **CI log prefix stripping**: `parse_test_output()` now strips the `<job><tab><step><tab><timestamp>` prefix that `gh run view --log` adds to every line. FAILED lines and summary counts are now correctly parsed from CI logs.
- **Coder stall detection**: `run_coder()` now uses `Popen` with a background thread monitoring stdout. If no output for 120s (`CODER_STALL_TIMEOUT`), the process is killed and `AgentStalledError` is raised. The orchestrator exits with code 2 and leaves the branch untouched for human inspection.

## Exit codes

| Code | Meaning |
|---|---|
| 0 | Pipeline approved, PR ready |
| 1 | Pipeline rejected after max attempts / unexpected error / interrupted |
| 2 | Agent stalled — branch left as-is for inspection |

## Test plan

- [ ] Verify CI log parsing by running against a known CI run with failures
- [ ] Verify stall detection by running the Coder on an issue that triggers a permission prompt (should kill after 120s, not 600s)
- [ ] Confirm exit code 2 and "Branch left as-is" message on stall
- [ ] Confirm partial output is saved to `stall-dump-attempt-1.txt`