### PR TITLE
fix: use stdbuf for line-buffered stdout in stall detection

### DIFF
--- a/harness/agents.py
+++ b/harness/agents.py
@@ -189,8 +189,11 @@ def run_coder(
         "10",
     ]
 
+    # stdbuf -oL forces line-buffered stdout on the child process.
+    # Without this, pipe buffering means our stall detector sees
+    # no output even while the agent is actively working.
     raw_out, raw_err, stalled = _run_with_stall_detection(
-        cmd,
+        ["stdbuf", "-oL", *cmd],
         cwd=cwd,
         hard_timeout=CODER_TIMEOUT,
         stall_timeout=CODER_STALL_TIMEOUT,


### PR DESCRIPTION
## Summary

Wraps the Coder's `claude` subprocess with `stdbuf -oL` to force line-buffered stdout. Without this, pipe buffering causes the stall detector to see no output even while the agent is actively working, triggering a false stall kill after 120s.

## Context

After adding Popen-based stall detection (PR #96), the Coder was immediately killed as "stalled" with empty stdout/stderr logs. The agent was working fine — its output was stuck in an unflushed 4-8KB pipe buffer.

## Test plan

- [ ] Run `uv run harness run <issue>` and verify the Coder runs past 120s without being killed
- [ ] Verify stall detection still fires on a genuine stall (e.g. permission prompt hang)