### PR TITLE
fix: track test and lint CI workflows separately

### DIFF
--- a/harness/ci.py
+++ b/harness/ci.py
@@ -40,32 +40,45 @@ def _run_gh(
     )
 
 
-def _poll_for_run(repo: str, branch: str) -> int:
-    """Poll until a CI run appears for the branch, then return its ID."""
+def _poll_for_run(
+    repo: str,
+    branch: str,
+    *,
+    workflow: str | None = None,
+) -> int:
+    """Poll until a CI run appears for the branch, then return its ID.
+
+    When *workflow* is given (e.g. ``"test.yml"``), only runs from
+    that workflow are considered.
+    """
     deadline = time.monotonic() + CI_POLL_MAX_WAIT
 
     while True:
-        result = _run_gh(
-            [
-                "run",
-                "list",
-                "--repo",
-                repo,
-                "--branch",
-                branch,
-                "--limit",
-                "1",
-                "--json",
-                "databaseId,status",
-            ],
-            check=True,
-        )
+        cmd = [
+            "run",
+            "list",
+            "--repo",
+            repo,
+            "--branch",
+            branch,
+            "--limit",
+            "1",
+            "--json",
+            "databaseId,status",
+        ]
+        if workflow:
+            cmd.extend(["--workflow", workflow])
+
+        result = _run_gh(cmd, check=True)
         runs = json.loads(result.stdout)
         if runs:
             return runs[0]["databaseId"]
 
         if time.monotonic() >= deadline:
-            msg = f"No CI runs found for branch {branch} after {CI_POLL_MAX_WAIT}s"
+            label = f" (workflow={workflow})" if workflow else ""
+            msg = (
+                f"No CI runs found for branch {branch}{label} after {CI_POLL_MAX_WAIT}s"
+            )
             raise RuntimeError(msg)
 
         logger.info(
@@ -75,35 +88,65 @@ def _poll_for_run(repo: str, branch: str) -> int:
         time.sleep(CI_POLL_INTERVAL)
 
 
-def wait_for_ci(repo: str, branch: str) -> int:
-    """Wait for the latest CI run on a branch to complete.
+@dataclass
+class CIResult:
+    """Aggregated result from all CI workflow runs."""
 
-    Returns the run ID.
+    test_run_id: int | None = None
+    lint_run_id: int | None = None
+    test_passed: bool = True
+    lint_passed: bool = True
 
-    GitHub Actions may take several seconds to register a workflow
-    run after a push, so this function polls until a run appears
-    (up to CI_POLL_MAX_WAIT seconds) before handing off to
-    ``gh run watch``.
+
+def wait_for_ci(repo: str, branch: str) -> CIResult:
+    """Wait for both Test and Lint CI runs on a branch to complete.
+
+    Returns a ``CIResult`` with per-workflow run IDs and pass/fail
+    status.  Test output should be parsed from ``test_run_id`` only.
+
+    GitHub Actions may take several seconds to register workflow
+    runs after a push, so this function polls until each run appears
+    (up to CI_POLL_MAX_WAIT seconds) before watching them.
     """
     logger.info("Waiting for CI on branch %s...", branch)
+    result = CIResult()
 
-    run_id = _poll_for_run(repo, branch)
-    logger.info("Found CI run %d, waiting for completion...", run_id)
+    for workflow, attr in [("test.yml", "test"), ("lint.yml", "lint")]:
+        try:
+            run_id = _poll_for_run(repo, branch, workflow=workflow)
+        except RuntimeError:
+            logger.warning("No %s run found for branch %s", workflow, branch)
+            continue
 
-    _run_gh(
-        [
-            "run",
-            "watch",
-            str(run_id),
-            "--repo",
-            repo,
-            "--exit-status",
-        ],
-        check=False,
-        timeout=CI_WATCH_TIMEOUT,
-    )
+        logger.info(
+            "Found %s run %d, waiting for completion...",
+            workflow,
+            run_id,
+        )
+        _run_gh(
+            [
+                "run",
+                "watch",
+                str(run_id),
+                "--repo",
+                repo,
+                "--exit-status",
+            ],
+            check=False,
+            timeout=CI_WATCH_TIMEOUT,
+        )
 
-    return run_id
+        passed = get_ci_status(repo, run_id)
+        setattr(result, f"{attr}_run_id", run_id)
+        setattr(result, f"{attr}_passed", passed)
+        logger.info(
+            "%s: %s (run %d)",
+            workflow,
+            "PASS" if passed else "FAIL",
+            run_id,
+        )
+
+    return result
 
 
 def get_ci_status(repo: str, run_id: int) -> bool:
@@ -188,6 +231,26 @@ def get_failed_logs(repo: str, run_id: int) -> str:
         )
         return ""
 
+    return result.stdout
+
+
+def get_run_log(repo: str, run_id: int) -> str:
+    """Get the full log for a CI run.
+
+    Used when ``--log-failed`` returns nothing (common with
+    ``continue-on-error: true`` steps).
+    """
+    result = _run_gh(
+        [
+            "run",
+            "view",
+            str(run_id),
+            "--repo",
+            repo,
+            "--log",
+        ],
+        check=False,
+    )
     return result.stdout
 
 

--- a/harness/orchestrator.py
+++ b/harness/orchestrator.py
@@ -24,14 +24,12 @@ from harness.agents import (
     save_output,
 )
 from harness.ci import (
+    CIResult,
     TestReport,
-    get_ci_status,
     get_failed_logs,
+    get_run_log,
     parse_test_output,
     wait_for_ci,
-)
-from harness.ci import (
-    _run_gh as _run_ci_gh,
 )
 from harness.state import (
     comment_on_issue,
@@ -530,31 +528,32 @@ def _single_attempt(
     )
 
     logger.info("Waiting for CI...")
-    run_id = wait_for_ci(repo, branch_name)
-    ci_passed = get_ci_status(repo, run_id)
-    logger.info("CI: %s (run %d)", "PASS" if ci_passed else "FAIL", run_id)
+    ci = wait_for_ci(repo, branch_name)
 
-    # --- Parse test results from CI logs ---
-    ci_log = get_failed_logs(repo, run_id)
-    if not ci_log:
-        # No failed logs — get full log for parsing
-        ci_log = _get_ci_log(repo, run_id)
-    test_report = parse_test_output(ci_log)
-    logger.info(
-        "Tests: %d passed, %d failed, %d errors (of %d total)",
-        test_report.passed,
-        test_report.failed,
-        test_report.errors,
-        test_report.total,
-    )
-    if ci_log:
-        save_output(
-            issue_number,
-            "ci-logs",
-            attempt,
-            ci_log,
-            log_dir,
+    # --- Parse test results from the Test workflow specifically ---
+    test_report = TestReport()
+    if ci.test_run_id:
+        test_log = get_failed_logs(repo, ci.test_run_id)
+        if not test_log:
+            test_log = get_run_log(repo, ci.test_run_id)
+        test_report = parse_test_output(test_log)
+        logger.info(
+            "Tests: %d passed, %d failed, %d errors (of %d total)",
+            test_report.passed,
+            test_report.failed,
+            test_report.errors,
+            test_report.total,
         )
+        if test_log:
+            save_output(
+                issue_number,
+                "ci-logs",
+                attempt,
+                test_log,
+                log_dir,
+            )
+    else:
+        logger.warning("No Test workflow run found — cannot parse test results")
 
     # --- Code review (LLM — diff + plan only) ---
     transition(
@@ -578,28 +577,11 @@ def _single_attempt(
     verdict = _assemble_verdict(
         lint_result=lint_result,
         test_report=test_report,
-        ci_passed=ci_passed,
-        ci_run_id=run_id,
+        ci=ci,
         findings=review_result.findings,
     )
     verdict.pr_url = pr_url
     return verdict
-
-
-def _get_ci_log(repo: str, run_id: int) -> str:
-    """Get the full CI log for a run (used when --log-failed is empty)."""
-    result = _run_ci_gh(
-        [
-            "run",
-            "view",
-            str(run_id),
-            "--repo",
-            repo,
-            "--log",
-        ],
-        check=False,
-    )
-    return result.stdout
 
 
 def _load_baseline() -> dict:
@@ -614,8 +596,7 @@ def _assemble_verdict(
     *,
     lint_result: SensorResult,
     test_report: TestReport,
-    ci_passed: bool,
-    ci_run_id: int,
+    ci: CIResult,
     findings: list[dict] | None,
 ) -> Verdict:
     """Build a deterministic verdict from sensors + code review."""
@@ -644,11 +625,18 @@ def _assemble_verdict(
             len(test_report.failed_tests),
         )
 
-    # CI failed but no test failures parsed (infra issue)
-    if not ci_passed and not test_report.failed_tests:
+    # Test CI failed but no test failures parsed (infra issue)
+    if not ci.test_passed and not test_report.failed_tests:
         reasons.append(
-            f"CI failed (run {ci_run_id}) — no test "
+            f"Test CI failed (run {ci.test_run_id}) — no test "
             f"failures parsed, possible infra issue"
+        )
+
+    # Lint CI failed — informational only, local lint is authoritative
+    if not ci.lint_passed:
+        logger.info(
+            "Lint CI failed (run %d) — local lint sensor is authoritative.",
+            ci.lint_run_id,
         )
 
     # Code review findings
@@ -664,7 +652,7 @@ def _assemble_verdict(
     return Verdict(
         approved=approved,
         reasons=reasons,
-        ci_run_id=ci_run_id,
+        ci_run_id=ci.test_run_id,
         findings=findings or [],
     )
 


### PR DESCRIPTION
## Summary
- `wait_for_ci` was using `gh run list --limit 1` which grabbed whichever workflow run appeared first — often the Lint run instead of the Test run
- Test output parsing then failed because lint logs contain no pytest output, and `Prepared 84 packages in 2.17s` false-matched the summary regex, producing `0 passed, 0 failed, 0 errors (of 84 total)` and a spurious "possible infra issue" rejection
- Now polls for `test.yml` and `lint.yml` independently via `--workflow` filter, returns a structured `CIResult`, and only parses test output from the Test workflow run
- Lint CI failures are logged but not blocking (local lint sensor is authoritative)

## Test plan
- [ ] Run `uv run harness run <issue>` on an `agent-ready` issue and verify:
  - Both workflow runs are tracked separately in the orchestrator log
  - Test results show correct counts (not `0 passed, 0 failed`)
  - Lint CI failure does not cause a false "infra issue" rejection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced CI workflow monitoring to independently track test and lint workflows with structured result reporting.
  * Improved run log retrieval for failed CI workflows when standard logs are unavailable.
  * Updated CI result evaluation to handle workflow-specific failures and status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->