### PR TITLE
chore: prevent coder agent from suppressing lint violations

### DIFF
--- a/harness/prompts/coder.md
+++ b/harness/prompts/coder.md
@@ -35,7 +35,8 @@ git checkout {branch_name}
    - Prefix any debug prints with `[DEBUG]`
 5. After writing code, run `ruff check . --fix` and `ruff format .` to fix lint issues.
 6. Commit your changes with a descriptive message. Do not add co-author lines.
-7. Do not modify migration files, settings files, or root conftest.py.
+7. Do not modify migration files, settings files, pyproject.toml, or root conftest.py.
+8. Do not suppress lint violations by adding `# noqa` comments or editing ruff config. Fix the underlying code instead.
 
 ## Output
 

--- a/harness/prompts/conventions.md
+++ b/harness/prompts/conventions.md
@@ -32,6 +32,7 @@ These paths require human review and must not be changed by agents:
 
 - `blueflow/migrations/` — never edit migration files directly
 - `project/settings/` — settings changes require human review
+- `pyproject.toml` — never modify linter config, dependencies, or project metadata
 - `conftest.py` (root) — shared test infrastructure; changes affect all tests
 - Any file outside `blueflow/` and `tests/` without explicit plan approval
 


### PR DESCRIPTION
## Summary

- Add `pyproject.toml` to the Do Not Modify list in `conventions.md`
- Add explicit instruction in `coder.md` to fix lint violations instead of adding `# noqa` comments or editing ruff config
- Use Sonnet for the coder agent for faster plan execution; planner and reviewer remain on Opus

Motivated by issue #65 where the coder agent added `DJ001` to the global ignore list and blanket per-file-ignores rather than fixing the underlying violations.

## Test plan

- [ ] Run the harness against an issue with lint violations and verify the coder attempts fixes instead of suppressions
- [ ] Verify coder agent uses Sonnet (check `--model sonnet` in subprocess args)