### PR TITLE
chore: use sonnet for coder agent

### DIFF
--- a/harness/agents.py
+++ b/harness/agents.py
@@ -151,6 +151,8 @@ def run_coder(
         "--print",
         "-p",
         prompt,
+        "--model",
+        "sonnet",
         "--allowedTools",
         "Read",
         "Glob",


### PR DESCRIPTION
## Summary

- Use Sonnet for the coder agent for faster plan execution and lint fixes
- Planner and code reviewer remain on Opus for deeper reasoning

## Test plan

- [ ] Run the harness against an issue and verify coder uses Sonnet