### PR TITLE
feat: resume coder session on lint retries

### DIFF
--- a/harness/agents.py
+++ b/harness/agents.py
@@ -5,6 +5,7 @@ import json
 import logging
 import re
 import subprocess
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -131,38 +132,69 @@ def run_planner(issue_context: str) -> PlanResult:
     return PlanResult(raw_output=raw, plan=plan)
 
 
+def generate_session_id() -> str:
+    """Generate a new session ID for coder session continuity."""
+    return str(uuid.uuid4())
+
+
 def run_coder(
     plan_json: str,
     branch_name: str,
     feedback: str | None = None,
     cwd: str | None = None,
+    session_id: str | None = None,
+    *,
+    resume: bool = False,
 ) -> CoderResult:
-    """Invoke the Coder agent to implement the plan."""
-    template = load_prompt("coder")
-    feedback_section = f"\n\n## Reviewer Feedback\n{feedback}" if feedback else ""
-    prompt = (
-        template.replace("{plan}", plan_json)
-        .replace("{branch_name}", branch_name)
-        .replace("{feedback_section}", feedback_section)
-    )
+    """Invoke the Coder agent to implement the plan.
 
-    cmd = [
-        "claude",
-        "--print",
-        "-p",
-        prompt,
-        "--model",
-        "sonnet",
-        "--allowedTools",
-        "Read",
-        "Glob",
-        "Grep",
-        "Edit",
-        "Write",
-        "Bash",
-        "--max-budget-usd",
-        "10",
-    ]
+    When *session_id* is provided on the first call (resume=False),
+    the session is pinned so that lint retries can resume it.
+    When *resume* is True, the existing session is continued with
+    only the feedback as the new prompt — no plan re-injection.
+    """
+    if resume and session_id:
+        # Resume existing session — only send the feedback as the prompt
+        cmd = [
+            "claude",
+            "--print",
+            "--resume",
+            session_id,
+            "--model",
+            "sonnet",
+            "-p",
+            feedback or "Continue.",
+            "--max-budget-usd",
+            "10",
+        ]
+    else:
+        template = load_prompt("coder")
+        feedback_section = f"\n\n## Reviewer Feedback\n{feedback}" if feedback else ""
+        prompt = (
+            template.replace("{plan}", plan_json)
+            .replace("{branch_name}", branch_name)
+            .replace("{feedback_section}", feedback_section)
+        )
+
+        cmd = [
+            "claude",
+            "--print",
+            "-p",
+            prompt,
+            "--model",
+            "sonnet",
+            "--allowedTools",
+            "Read",
+            "Glob",
+            "Grep",
+            "Edit",
+            "Write",
+            "Bash",
+            "--max-budget-usd",
+            "10",
+        ]
+        if session_id:
+            cmd.extend(["--session-id", session_id])
 
     try:
         result = subprocess.run(

--- a/harness/orchestrator.py
+++ b/harness/orchestrator.py
@@ -14,6 +14,7 @@ import click
 from harness.agents import (
     SensorResult,
     create_draft_pr,
+    generate_session_id,
     get_changed_files,
     get_diff,
     push_branch,
@@ -415,8 +416,11 @@ def _code_and_lint(
 
     Returns the final lint SensorResult (passed or not).
     """
+    session_id = generate_session_id()
+
     for lint_try in range(1 + MAX_LINT_RETRIES):
-        suffix = f" (lint retry {lint_try})" if lint_try > 0 else ""
+        is_retry = lint_try > 0
+        suffix = f" (lint retry {lint_try})" if is_retry else ""
         logger.info(
             "Starting Coder agent (attempt %d%s)...",
             attempt,
@@ -427,11 +431,13 @@ def _code_and_lint(
             branch_name,
             feedback=feedback,
             cwd=cwd,
+            session_id=session_id,
+            resume=is_retry,
         )
         save_output(
             issue_number,
             "coder",
-            attempt if lint_try == 0 else f"{attempt}-lint{lint_try}",
+            attempt if not is_retry else f"{attempt}-lint{lint_try}",
             coder_result.raw_output,
             log_dir,
         )


### PR DESCRIPTION
## Summary

- Pin a session ID (`--session-id`) on the first coder invocation
- On lint retries, use `--resume` to continue the same session instead of cold-starting a new subprocess
- The coder retains its full context (files read, plan understanding, edits made) and only receives the lint feedback as a new prompt

This eliminates the ~10 minute context rebuild observed on issue #65 lint retries, where the coder re-read every file and re-parsed the plan before making a small fix.

## Changes

- `agents.py`: Add `generate_session_id()`, add `session_id` and `resume` params to `run_coder()`
- `orchestrator.py`: Generate session ID in `_code_and_lint()`, pass through to `run_coder()` with `resume=True` on retries

## Test plan

- [ ] Run the harness on an issue that triggers a lint retry and verify the retry uses `--resume` (check logs for faster turnaround)
- [ ] Verify first coder call still works normally with `--session-id`