### PR TITLE
dx(docker): preflight uv check in run-local.sh sidecar mode

### DIFF
--- a/docker/run-local.sh
+++ b/docker/run-local.sh
@@ -76,6 +76,7 @@ echo "Logs: $OUTDIR/"
 ls -1 "$OUTDIR"/*.log
 
 if [ "${SIDECAR:-}" = "1" ]; then
+    command -v uv >/dev/null 2>&1 || { echo "Error: uv not found (required for SIDECAR=1)" >&2; exit 1; }
     echo ""
     echo "Running sidecar (dry-run)..."
     uv run "$ZEEK_PKG/sidecar.py" "$OUTDIR"


### PR DESCRIPTION
Resolves #122

## Plan
```json
{
  "issue_number": 122,
  "issue_title": "dx(docker): preflight uv check in run-local.sh sidecar mode",
  "classification": "chore",
  "branch_name": "chore/122-preflight-uv-check",
  "affected_files": [
    "docker/run-local.sh"
  ],
  "plan_steps": [
    {
      "step": 1,
      "description": "Create a new branch `chore/122-preflight-uv-check` based on the latest `origin/develop` before making any changes.",
      "file": "(git)",
      "rationale": "Per CLAUDE.md and agent conventions: never commit directly to develop/main; chore prefix matches the dx tooling fix classification."
    },
    {
      "step": 2,
      "description": "In the SIDECAR branch (currently lines 78\u201382), insert a `command -v uv` preflight as the first statement inside the `if [ \"${SIDECAR:-}\" = \"1\" ]; then` block, exactly matching the existing pattern at lines 55\u201356 for `zeek` and `spicyz`. The new line should read: `command -v uv >/dev/null 2>&1 || { echo \"Error: uv not found (required for SIDECAR=1)\" >&2; exit 1; }` and be placed immediately after the `then` and before the existing `echo \"\"`.",
      "file": "docker/run-local.sh",
      "rationale": "Aligns the SIDECAR branch with the script's existing preflight idiom so a missing `uv` produces a clear, actionable error instead of a cryptic shell failure. Placing the check inside the SIDECAR conditional ensures users who don't opt into SIDECAR are not penalized for not having `uv` installed."
    },
    {
      "step": 3,
      "description": "Manually verify the change by running `bash -n docker/run-local.sh` to syntax-check the script. Optionally run `SIDECAR=1 PATH=/usr/bin:/bin ./docker/run-local.sh` (a PATH that excludes uv) to confirm the new error message fires and the script exits 1 before invoking `uv run`. Also run a normal invocation (without SIDECAR=1) to confirm the non-SIDECAR path is unchanged.",
      "file": "docker/run-local.sh",
      "rationale": "This is a shell-script-only change with no Python tests covering it; a syntax check plus a behavioral spot-check is the appropriate validation."
    },
    {
      "step": 4,
      "description": "Commit the change with a message like `chore(docker): preflight uv check in run-local.sh sidecar mode` (no co-author lines, no Claude attribution) and push the branch.",
      "file": "(git)",
      "rationale": "Follows commit conventions in CLAUDE.md and the agent rules in this prompt."
    }
  ],
  "risks": [
    "The exact diff in the issue uses 4-space indentation; the existing script uses 4-space indentation inside the `if` block, so this should match \u2014 but indentation must be verified to keep the patch visually consistent with surrounding lines.",
    "No automated test exercises this script, so regressions in the SIDECAR branch can only be caught by a human running it locally with and without `uv` on PATH.",
    "The change is gated to the SIDECAR=1 path, so users who never opt in are unaffected; nonetheless reviewers should confirm the check is *inside* the conditional, not at the top of the script."
  ],
  "acceptance_criteria": [
    "When `SIDECAR=1 ./docker/run-local.sh` is invoked and `uv` is not on PATH, the script prints `Error: uv not found (required for SIDECAR=1)` to stderr and exits with status 1, before any attempt to call `uv run`.",
    "When `SIDECAR=1 ./docker/run-local.sh` is invoked and `uv` *is* on PATH, behavior is identical to before this change (sidecar dry-run still executes).",
    "When the script is invoked without `SIDECAR=1`, it does not check for `uv` and behavior is unchanged regardless of whether `uv` is installed.",
    "The new preflight line is structurally consistent with the existing `zeek`/`spicyz` checks at lines 55\u201356 (same `command -v \u2026 >/dev/null 2>&1 || { echo \u2026 >&2; exit 1; }` shape).",
    "`bash -n docker/run-local.sh` exits 0."
  ],
  "estimated_complexity": "low"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to fail fast with a clear error message when a required dependency is missing during local execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->