### PR TITLE
docs(docker): add language hint to README layout fenced block

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -17,7 +17,7 @@ unit testing of the Python ingest path lives in
 
 ## Layout
 
-```
+```text
 docker/
   docker-compose.yml          # 5-service compose (stub + real profiles)
   run-local.sh                # non-docker zeek + sidecar local run


### PR DESCRIPTION
Resolves #120

> **chore** · complexity: **low** · branch: `chore/120-docker-readme-md040-language-hint`

## Summary

docs(docker): add language hint to README layout fenced block

## Plan

1. **Change the opening fence on line 20 of docker/README.md from ``` to ```text so the layout block declares a language token and satisfies markdownlint MD040.**
   - File: `docker/README.md`
   - Why: The fenced block at line 20 is the only one in this file without a language identifier. Adding `text` is the lowest-impact token for a non-code (directory tree) block and is the explicit fix suggested in the issue body.

## Affected files

- `docker/README.md`

## Acceptance criteria

- [x] The opening fence on line 20 of docker/README.md reads ```text instead of ```.
- [x] The closing fence on line 39 remains ``` (no language token on close).
- [x] markdownlint-cli2 no longer reports MD040 against docker/README.md.
- [x] No other content in docker/README.md is modified.

## Risks

- Other fenced blocks in the file already declare languages (`bash`), so this single-line change should not affect rendering or surrounding content; the only risk is accidentally editing the wrong fence (the closing fence on line 39 must remain unchanged).

---

<details><summary>Raw plan (JSON)</summary>

```json
{
  "issue_number": 120,
  "issue_title": "docs(docker): add language hint to README layout fenced block",
  "classification": "chore",
  "branch_name": "chore/120-docker-readme-md040-language-hint",
  "affected_files": [
    "docker/README.md"
  ],
  "plan_steps": [
    {
      "step": 1,
      "description": "Change the opening fence on line 20 of docker/README.md from ``` to ```text so the layout block declares a language token and satisfies markdownlint MD040.",
      "file": "docker/README.md",
      "rationale": "The fenced block at line 20 is the only one in this file without a language identifier. Adding `text` is the lowest-impact token for a non-code (directory tree) block and is the explicit fix suggested in the issue body."
    }
  ],
  "risks": [
    "Other fenced blocks in the file already declare languages (`bash`), so this single-line change should not affect rendering or surrounding content; the only risk is accidentally editing the wrong fence (the closing fence on line 39 must remain unchanged)."
  ],
  "acceptance_criteria": [
    "The opening fence on line 20 of docker/README.md reads ```text instead of ```.",
    "The closing fence on line 39 remains ``` (no language token on close).",
    "markdownlint-cli2 no longer reports MD040 against docker/README.md.",
    "No other content in docker/README.md is modified."
  ],
  "estimated_complexity": "low"
}
```

</details>