### PR TITLE
docs(zeek): add language hint to README component-tree fenced block

### DIFF
--- a/blueflow/zeek/README.md
+++ b/blueflow/zeek/README.md
@@ -5,7 +5,7 @@ Zeek log ingest for BlueFlow Asset records. Promoted from spike #111
 
 ## Components
 
-```
+```text
 blueflow/zeek/
   __init__.py
   sidecar.py                 # Log loader + correlator + aggregator


### PR DESCRIPTION
Resolves #119

> **chore** · complexity: **low** · branch: `chore/119-zeek-readme-md040`

## Summary

docs(zeek): add language hint to README component-tree fenced block

## Plan

1. **On line 8 of blueflow/zeek/README.md, change the opening fence from ``` to ```text so the component-tree code block declares a language identifier and satisfies markdownlint MD040.**
   - File: `blueflow/zeek/README.md`
   - Why: MD040 requires every fenced code block to specify a language. The block at line 8 is a directory tree, so `text` is the appropriate identifier — matching the convention established in commit 38d4cf8 for the docker README's layout block.

## Affected files

- `blueflow/zeek/README.md`

## Acceptance criteria

- [x] The opening fence on line 8 of blueflow/zeek/README.md reads ```text instead of ```.
- [x] markdownlint-cli2 no longer reports MD040 against blueflow/zeek/README.md.
- [x] Rendered content of the component-tree block is unchanged.

## Risks

- None of substance — this is a one-character documentation change. Closing fence at line 17 is already plain ``` and does not need modification.

---

<details><summary>Raw plan (JSON)</summary>

```json
{
  "issue_number": 119,
  "issue_title": "docs(zeek): add language hint to README component-tree fenced block",
  "classification": "chore",
  "branch_name": "chore/119-zeek-readme-md040",
  "affected_files": [
    "blueflow/zeek/README.md"
  ],
  "plan_steps": [
    {
      "step": 1,
      "description": "On line 8 of blueflow/zeek/README.md, change the opening fence from ``` to ```text so the component-tree code block declares a language identifier and satisfies markdownlint MD040.",
      "file": "blueflow/zeek/README.md",
      "rationale": "MD040 requires every fenced code block to specify a language. The block at line 8 is a directory tree, so `text` is the appropriate identifier \u2014 matching the convention established in commit 38d4cf8 for the docker README's layout block."
    }
  ],
  "risks": [
    "None of substance \u2014 this is a one-character documentation change. Closing fence at line 17 is already plain ``` and does not need modification."
  ],
  "acceptance_criteria": [
    "The opening fence on line 8 of blueflow/zeek/README.md reads ```text instead of ```.",
    "markdownlint-cli2 no longer reports MD040 against blueflow/zeek/README.md.",
    "Rendered content of the component-tree block is unchanged."
  ],
  "estimated_complexity": "low"
}
```

</details>