### PR TITLE
chore: migrate os.path / os.remove / open() to pathlib (PTH)

### DIFF
--- a/blueflow/csv/__init__.py
+++ b/blueflow/csv/__init__.py
@@ -3,8 +3,8 @@
 import csv as pycsv
 import json
 import logging
-import os
 from collections import OrderedDict
+from pathlib import Path
 
 import celery
 from django.apps import apps
@@ -87,7 +87,7 @@ logger = celery.utils.log.get_task_logger(__name__)
 
 def linecount(filename):
     """Return the number of lines in a file."""
-    with open(filename) as filehandle:
+    with Path(filename).open() as filehandle:
         return sum(1 for row in filehandle)
 
 
@@ -101,7 +101,7 @@ def process_csv(ctx, filename, field_mapping, require_network_info, update_only)
     # The 'utf-8-sig' encoding makes us robust to Excel-exported CSV
     # files (they contain a 3-byte "byte order mark" at the beginning of
     # the file.)
-    with open(filename, encoding="utf-8-sig") as csv_file:
+    with Path(filename).open(encoding="utf-8-sig") as csv_file:
         stats = {
             "total": 0,
             "updated": 0,
@@ -244,12 +244,9 @@ def main(
 
     # Save attachment provided by the web UI, if any
     if ctx.ct.attachment:
-        filename = os.path.join(
-            django_settings.MEDIA_ROOT,
-            ctx.ct.attachment.name,
-        )
+        filename = Path(django_settings.MEDIA_ROOT) / ctx.ct.attachment.name
         logger.debug("Saved file %s", filename)
-        if not os.path.exists(filename):
+        if not Path(filename).exists():
             raise ValueError(f"File not found: {filename}")
 
     # Read field mapping from the database if one is not provided
@@ -270,4 +267,4 @@ def main(
 
     # Remove temporary file
     if ctx.ct.attachment:
-        os.remove(filename)
+        Path(filename).unlink()

--- a/blueflow/management/commands/create_assets.py
+++ b/blueflow/management/commands/create_assets.py
@@ -2,6 +2,7 @@
 
 import json
 from collections.abc import Generator
+from pathlib import Path
 
 from django.apps import apps
 from django.core.management.base import BaseCommand
@@ -46,7 +47,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options) -> None:
         Asset = apps.get_model("blueflow", "Asset")
         file_path = options.get("filepath")
-        with open(file_path, encoding="utf-8") as file:
+        with Path(file_path).open(encoding="utf-8") as file:
             data = json.loads(file.read())
             assets = make_assets(data)
             Asset.objects.bulk_create([Asset(**asset) for asset in assets])


### PR DESCRIPTION
Resolves #130

> **chore** · complexity: **low** · branch: `chore/130-pathlib-migration`

## Summary

chore: migrate os.path / os.remove / open() to pathlib (PTH)

## Plan

1. **In linecount(), replace `with open(filename) as filehandle:` (line 90) with `with Path(filename).open() as filehandle:`. In process_csv(), replace `with open(filename, encoding='utf-8-sig') as csv_file:` (line 104) with `with Path(filename).open(encoding='utf-8-sig') as csv_file:`. Replace `os.path.join(django_settings.MEDIA_ROOT, ctx.ct.attachment.name)` (line 247) with `Path(django_settings.MEDIA_ROOT) / ctx.ct.attachment.name` and update `filename` to remain a string-compatible value (cast to str if downstream code requires str, otherwise leave as Path). Replace `not os.path.exists(filename)` (line 252) with `not Path(filename).exists()` (default follow_symlinks; no symlink-specific intent in surrounding code). Replace `os.remove(filename)` (line 273) with `Path(filename).unlink()` — preserve FileNotFoundError semantics; do NOT add missing_ok=True. Remove `import os` (line 6) and add `from pathlib import Path`. Verify no other `os.` references remain.**
   - File: `blueflow/csv/__init__.py`
   - Why: Covers PTH107, PTH110, PTH118, PTH123 (x2). Note: `filename` is later passed to `process_csv` and `linecount` which now both use `Path(...).open(...)`, which accepts both str and Path, so casting to str isn't required, but if downstream code calls `.name` on attachment, leave attachment.name access intact. The os.remove call sits inside `if ctx.ct.attachment:` after a successful download, so the file should always exist — preserving raise-on-missing matches current semantics.
2. **In handle(), replace `with open(file_path, encoding='utf-8') as file:` (line 49) with `with Path(file_path).open(encoding='utf-8') as file:`. Add `from pathlib import Path` to imports.**
   - File: `blueflow/management/commands/create_assets.py`
   - Why: PTH123. file_path is a CLI-supplied string path, plain control flow — straight Path.open conversion is correct.
3. **Replace all three `open(filename, encoding='utf-8') as fh:` calls (lines 17, 27, 39) with `Path(filename).open(encoding='utf-8') as fh:`. Replace all five `os.unlink(filename)` calls (lines 19, 29, 41, 71, 102) with `Path(filename).unlink()` — preserve raise-on-missing; tempfiles are always present at these points so missing_ok would mask bugs. Remove `import os` and add `from pathlib import Path`.**
   - File: `blueflow/tests/test_csv_byte_order_mark.py`
   - Why: PTH108 (x5), PTH123 (x3). All sites operate on freshly-written tempfiles in test bodies — straight migration with no semantic change.
4. **Replace all three `os.unlink(filename)` calls (lines 44, 83, 124) with `Path(filename).unlink()`. Remove `import os` and add `from pathlib import Path`.**
   - File: `blueflow/tests/test_csv_custom_field.py`
   - Why: PTH108 (x3). Same rationale as test_csv_byte_order_mark.py — tempfile cleanup, preserve raise-on-missing.
5. **In path_nparent(), replace `path = os.path.dirname(path)` (line 9) with `path = str(Path(path).parent)` to preserve the str return type used by BLUEFLOW_HOME consumers. Append `# noqa: PTH123` to the `with open(csvfd, 'w', encoding=encoding) as fh:` line (line 31) — `csvfd` is a file descriptor from tempfile.mkstemp, which Path.open does not accept; per issue guidance, fd-based open() stays as-is. Add `from pathlib import Path` to imports. Do NOT remove `import os` (still used implicitly? — verify; only `os.path.dirname` was used, so `import os` should be removed).**
   - File: `blueflow/tests/utils/__init__.py`
   - Why: PTH120, PTH123. Path.parent returns a Path; existing callers (BLUEFLOW_HOME) may rely on str. Wrapping in str() preserves the contract. The fd-open must stay; noqa is the documented escape hatch.
6. **Append `# noqa: PTH123` to `with open(csvfd, 'w') as csvfile:` (line 15). `csvfd` is a file descriptor from tempfile.mkstemp — Path.open does not accept fds. No imports change.**
   - File: `blueflow/tests/utils/mssql_client_mock.py`
   - Why: PTH123. File-descriptor open is explicitly called out in the issue as a stay-as-is case.

## Affected files

- `blueflow/csv/__init__.py`
- `blueflow/management/commands/create_assets.py`
- `blueflow/tests/test_csv_byte_order_mark.py`
- `blueflow/tests/test_csv_custom_field.py`
- `blueflow/tests/utils/__init__.py`
- `blueflow/tests/utils/mssql_client_mock.py`

## Acceptance criteria

- [ ] `uv run ruff check . --select PTH` exits 0 (zero violations).
- [ ] `uv run ruff check .` does not report new F401 (unused import) warnings for the removed `import os` lines.
- [ ] `uv run ruff format --check .` exits 0.
- [ ] `uv run pytest blueflow/tests/test_csv_byte_order_mark.py blueflow/tests/test_csv_custom_field.py -v` shows no new failures vs the documented ~68-test baseline.
- [ ] All `os.remove` / `os.unlink` translations preserve FileNotFoundError semantics — no `missing_ok=True` added.
- [ ] Two file-descriptor `open()` calls (tests/utils/__init__.py:31, tests/utils/mssql_client_mock.py:15) remain as `open(fd, ...)` with `# noqa: PTH123`.

## Risks

- tests/utils/__init__.py uses tempfile.mkstemp without an import statement — appears to be a latent bug unrelated to this issue; leave untouched (out of scope).
- BLUEFLOW_HOME = path_nparent(__file__, 5) consumers may compare the value as a string; wrapping Path(...).parent in str() in path_nparent preserves the str contract. Verify no consumer expects a Path.
- csv/__init__.py: replacing os.path.join with Path division produces a Path object. If filename is later passed to APIs that require str (e.g., logging is fine, but some libraries are strict), test for regressions; Path.open and Path.unlink both accept Path, and process_csv is called with this filename and uses Path(filename).open — safe.
- Adding # noqa: PTH123 in two files reduces the post-migration count visible to ruff but matches the issue's explicit fd-open guidance.

---

<details><summary>Raw plan (JSON)</summary>

```json
{
  "issue_number": 130,
  "issue_title": "chore: migrate os.path / os.remove / open() to pathlib (PTH)",
  "classification": "chore",
  "branch_name": "chore/130-pathlib-migration",
  "affected_files": [
    "blueflow/csv/__init__.py",
    "blueflow/management/commands/create_assets.py",
    "blueflow/tests/test_csv_byte_order_mark.py",
    "blueflow/tests/test_csv_custom_field.py",
    "blueflow/tests/utils/__init__.py",
    "blueflow/tests/utils/mssql_client_mock.py"
  ],
  "delete_files": [],
  "plan_steps": [
    {
      "step": 1,
      "description": "In linecount(), replace `with open(filename) as filehandle:` (line 90) with `with Path(filename).open() as filehandle:`. In process_csv(), replace `with open(filename, encoding='utf-8-sig') as csv_file:` (line 104) with `with Path(filename).open(encoding='utf-8-sig') as csv_file:`. Replace `os.path.join(django_settings.MEDIA_ROOT, ctx.ct.attachment.name)` (line 247) with `Path(django_settings.MEDIA_ROOT) / ctx.ct.attachment.name` and update `filename` to remain a string-compatible value (cast to str if downstream code requires str, otherwise leave as Path). Replace `not os.path.exists(filename)` (line 252) with `not Path(filename).exists()` (default follow_symlinks; no symlink-specific intent in surrounding code). Replace `os.remove(filename)` (line 273) with `Path(filename).unlink()` \u2014 preserve FileNotFoundError semantics; do NOT add missing_ok=True. Remove `import os` (line 6) and add `from pathlib import Path`. Verify no other `os.` references remain.",
      "file": "blueflow/csv/__init__.py",
      "rationale": "Covers PTH107, PTH110, PTH118, PTH123 (x2). Note: `filename` is later passed to `process_csv` and `linecount` which now both use `Path(...).open(...)`, which accepts both str and Path, so casting to str isn't required, but if downstream code calls `.name` on attachment, leave attachment.name access intact. The os.remove call sits inside `if ctx.ct.attachment:` after a successful download, so the file should always exist \u2014 preserving raise-on-missing matches current semantics."
    },
    {
      "step": 2,
      "description": "In handle(), replace `with open(file_path, encoding='utf-8') as file:` (line 49) with `with Path(file_path).open(encoding='utf-8') as file:`. Add `from pathlib import Path` to imports.",
      "file": "blueflow/management/commands/create_assets.py",
      "rationale": "PTH123. file_path is a CLI-supplied string path, plain control flow \u2014 straight Path.open conversion is correct."
    },
    {
      "step": 3,
      "description": "Replace all three `open(filename, encoding='utf-8') as fh:` calls (lines 17, 27, 39) with `Path(filename).open(encoding='utf-8') as fh:`. Replace all five `os.unlink(filename)` calls (lines 19, 29, 41, 71, 102) with `Path(filename).unlink()` \u2014 preserve raise-on-missing; tempfiles are always present at these points so missing_ok would mask bugs. Remove `import os` and add `from pathlib import Path`.",
      "file": "blueflow/tests/test_csv_byte_order_mark.py",
      "rationale": "PTH108 (x5), PTH123 (x3). All sites operate on freshly-written tempfiles in test bodies \u2014 straight migration with no semantic change."
    },
    {
      "step": 4,
      "description": "Replace all three `os.unlink(filename)` calls (lines 44, 83, 124) with `Path(filename).unlink()`. Remove `import os` and add `from pathlib import Path`.",
      "file": "blueflow/tests/test_csv_custom_field.py",
      "rationale": "PTH108 (x3). Same rationale as test_csv_byte_order_mark.py \u2014 tempfile cleanup, preserve raise-on-missing."
    },
    {
      "step": 5,
      "description": "In path_nparent(), replace `path = os.path.dirname(path)` (line 9) with `path = str(Path(path).parent)` to preserve the str return type used by BLUEFLOW_HOME consumers. Append `# noqa: PTH123` to the `with open(csvfd, 'w', encoding=encoding) as fh:` line (line 31) \u2014 `csvfd` is a file descriptor from tempfile.mkstemp, which Path.open does not accept; per issue guidance, fd-based open() stays as-is. Add `from pathlib import Path` to imports. Do NOT remove `import os` (still used implicitly? \u2014 verify; only `os.path.dirname` was used, so `import os` should be removed).",
      "file": "blueflow/tests/utils/__init__.py",
      "rationale": "PTH120, PTH123. Path.parent returns a Path; existing callers (BLUEFLOW_HOME) may rely on str. Wrapping in str() preserves the contract. The fd-open must stay; noqa is the documented escape hatch."
    },
    {
      "step": 6,
      "description": "Append `# noqa: PTH123` to `with open(csvfd, 'w') as csvfile:` (line 15). `csvfd` is a file descriptor from tempfile.mkstemp \u2014 Path.open does not accept fds. No imports change.",
      "file": "blueflow/tests/utils/mssql_client_mock.py",
      "rationale": "PTH123. File-descriptor open is explicitly called out in the issue as a stay-as-is case."
    }
  ],
  "risks": [
    "tests/utils/__init__.py uses tempfile.mkstemp without an import statement \u2014 appears to be a latent bug unrelated to this issue; leave untouched (out of scope).",
    "BLUEFLOW_HOME = path_nparent(__file__, 5) consumers may compare the value as a string; wrapping Path(...).parent in str() in path_nparent preserves the str contract. Verify no consumer expects a Path.",
    "csv/__init__.py: replacing os.path.join with Path division produces a Path object. If filename is later passed to APIs that require str (e.g., logging is fine, but some libraries are strict), test for regressions; Path.open and Path.unlink both accept Path, and process_csv is called with this filename and uses Path(filename).open \u2014 safe.",
    "Adding # noqa: PTH123 in two files reduces the post-migration count visible to ruff but matches the issue's explicit fd-open guidance."
  ],
  "acceptance_criteria": [
    "`uv run ruff check . --select PTH` exits 0 (zero violations).",
    "`uv run ruff check .` does not report new F401 (unused import) warnings for the removed `import os` lines.",
    "`uv run ruff format --check .` exits 0.",
    "`uv run pytest blueflow/tests/test_csv_byte_order_mark.py blueflow/tests/test_csv_custom_field.py -v` shows no new failures vs the documented ~68-test baseline.",
    "All `os.remove` / `os.unlink` translations preserve FileNotFoundError semantics \u2014 no `missing_ok=True` added.",
    "Two file-descriptor `open()` calls (tests/utils/__init__.py:31, tests/utils/mssql_client_mock.py:15) remain as `open(fd, ...)` with `# noqa: PTH123`."
  ],
  "estimated_complexity": "low"
}
```

</details>