### PR TITLE
chore: migrate os.path / os.remove / open() to pathlib (PTH)

### DIFF
--- a/blueflow/csv/__init__.py
+++ b/blueflow/csv/__init__.py
@@ -3,8 +3,8 @@
 import csv as pycsv
 import json
 import logging
-from pathlib import Path
 from collections import OrderedDict
+from pathlib import Path
 
 import celery
 from django.apps import apps

--- a/blueflow/csv/__init__.py
+++ b/blueflow/csv/__init__.py
@@ -3,7 +3,7 @@
 import csv as pycsv
 import json
 import logging
-import os
+from pathlib import Path
 from collections import OrderedDict
 
 import celery
@@ -87,7 +87,7 @@ logger = celery.utils.log.get_task_logger(__name__)
 
 def linecount(filename):
     """Return the number of lines in a file."""
-    with open(filename) as filehandle:
+    with Path(filename).open() as filehandle:
         return sum(1 for row in filehandle)
 
 
@@ -101,7 +101,7 @@ def process_csv(ctx, filename, field_mapping, require_network_info, update_only)
     # The 'utf-8-sig' encoding makes us robust to Excel-exported CSV
     # files (they contain a 3-byte "byte order mark" at the beginning of
     # the file.)
-    with open(filename, encoding="utf-8-sig") as csv_file:
+    with Path(filename).open(encoding="utf-8-sig") as csv_file:
         stats = {
             "total": 0,
             "updated": 0,
@@ -244,12 +244,9 @@ def main(
 
     # Save attachment provided by the web UI, if any
     if ctx.ct.attachment:
-        filename = os.path.join(
-            django_settings.MEDIA_ROOT,
-            ctx.ct.attachment.name,
-        )
+        filename = Path(django_settings.MEDIA_ROOT) / ctx.ct.attachment.name
         logger.debug("Saved file %s", filename)
-        if not os.path.exists(filename):
+        if not filename.exists():
             raise ValueError(f"File not found: {filename}")
 
     # Read field mapping from the database if one is not provided
@@ -270,4 +267,4 @@ def main(
 
     # Remove temporary file
     if ctx.ct.attachment:
-        os.remove(filename)
+        filename.unlink()

--- a/blueflow/management/commands/create_assets.py
+++ b/blueflow/management/commands/create_assets.py
@@ -2,6 +2,7 @@
 
 import json
 from collections.abc import Generator
+from pathlib import Path
 
 from django.apps import apps
 from django.core.management.base import BaseCommand
@@ -46,7 +47,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options) -> None:
         Asset = apps.get_model("blueflow", "Asset")
         file_path = options.get("filepath")
-        with open(file_path, encoding="utf-8") as file:
+        with Path(file_path).open(encoding="utf-8") as file:
             data = json.loads(file.read())
             assets = make_assets(data)
             Asset.objects.bulk_create([Asset(**asset) for asset in assets])

--- a/blueflow/tests/test_csv_byte_order_mark.py
+++ b/blueflow/tests/test_csv_byte_order_mark.py
@@ -1,7 +1,7 @@
 """Test CSV integration."""
 
-import os
 from codecs import BOM_UTF8
+from pathlib import Path
 
 from blueflow.csv import process_csv
 from blueflow.models import Asset
@@ -14,9 +14,9 @@ def test_tempfile_plain():
     """Test that the tempfile writer works as expected."""
     csv_orig = "A,B\n1,2\n"
     filename = write_tempfile(csv_orig)
-    with open(filename, encoding="utf-8") as fh:
+    with Path(filename).open(encoding="utf-8") as fh:
         csv = fh.read()
-    os.unlink(filename)
+    Path(filename).unlink()
     assert csv == csv_orig
 
 
@@ -24,9 +24,9 @@ def test_tempfile_manual_bom():
     """Insert BOM manually."""
     csv_orig = "A,B\n1,2\n"
     filename = write_tempfile(BOM_UTF8.decode("utf-8") + csv_orig)
-    with open(filename, encoding="utf-8") as fh:
+    with Path(filename).open(encoding="utf-8") as fh:
         csv = fh.read()
-    os.unlink(filename)
+    Path(filename).unlink()
     assert csv[0].encode("utf-8") == BOM_UTF8
     assert csv[0] == BOM_UTF8.decode("utf-8")
     assert csv[1:] == csv_orig
@@ -36,9 +36,9 @@ def test_tempfile_auto_bom():
     """Insert BOM with write_tempfile."""
     csv_orig = "A,B\n1,2\n"
     filename = write_tempfile(csv_orig, bom_utf8=True)
-    with open(filename, encoding="utf-8") as fh:
+    with Path(filename).open(encoding="utf-8") as fh:
         csv = fh.read()
-    os.unlink(filename)
+    Path(filename).unlink()
     assert csv[0].encode("utf-8") == BOM_UTF8
     assert csv[0] == BOM_UTF8.decode("utf-8")
     assert csv[1:] == csv_orig
@@ -68,7 +68,7 @@ def test_process_csv_without_bom(setup_db):
         require_network_info=False,
         update_only=True,
     )
-    os.unlink(filename)
+    Path(filename).unlink()
 
     asset = Asset.objects.last()
     assert asset.manufacturer == "Bar"
@@ -99,7 +99,7 @@ def test_process_csv_with_bom(setup_db):
         require_network_info=False,
         update_only=True,
     )
-    os.unlink(filename)
+    Path(filename).unlink()
 
     asset = Asset.objects.last()
     assert asset.manufacturer == "Bar"

--- a/blueflow/tests/test_csv_byte_order_mark.py
+++ b/blueflow/tests/test_csv_byte_order_mark.py
@@ -1,5 +1,6 @@
 """Test CSV integration."""
 
+import pytest
 from codecs import BOM_UTF8
 from pathlib import Path
 
@@ -44,7 +45,8 @@ def test_tempfile_auto_bom():
     assert csv[1:] == csv_orig
 
 
-def test_process_csv_without_bom(setup_db):
+@pytest.mark.usefixtures("setup_db")
+def test_process_csv_without_bom():
     """We can import from a CSV file that doesn't contains the BOM mark."""
     Asset.objects.create(
         manufacturer="Foo",
@@ -74,7 +76,8 @@ def test_process_csv_without_bom(setup_db):
     assert asset.manufacturer == "Bar"
 
 
-def test_process_csv_with_bom(setup_db):
+@pytest.mark.usefixtures("setup_db")
+def test_process_csv_with_bom():
     """We can import from a CSV file that contains the BOM mark."""
     Asset.objects.create(
         manufacturer="Foo",

--- a/blueflow/tests/test_csv_custom_field.py
+++ b/blueflow/tests/test_csv_custom_field.py
@@ -1,5 +1,6 @@
 """Test CSV integration."""
 
+import pytest
 from pathlib import Path
 
 from blueflow.csv import process_csv
@@ -9,7 +10,8 @@ from blueflow.tests.utils import write_tempfile
 from .test_csv import TestCTX
 
 
-def test_process_csv_with_custom_field(setup_db):
+@pytest.mark.usefixtures("setup_db")
+def test_process_csv_with_custom_field():
     """We can import from CSV into a custom field.
 
     Similar to test above but lower level (more unit test)
@@ -50,7 +52,8 @@ def test_process_csv_with_custom_field(setup_db):
     assert asset_shininess == "Very shiny"
 
 
-def test_process_csv_with_custom_field_underscores(setup_db):
+@pytest.mark.usefixtures("setup_db")
+def test_process_csv_with_custom_field_underscores():
     """We can import from CSV into a custom field that contains underscores."""
     Asset.objects.create(
         manufacturer="Foo",
@@ -91,7 +94,8 @@ def test_process_csv_with_custom_field_underscores(setup_db):
     assert asset_site_description == "Very shiny"
 
 
-def test_process_csv_with_custom_field_spaces(setup_db):
+@pytest.mark.usefixtures("setup_db")
+def test_process_csv_with_custom_field_spaces():
     """We can import from CSV into a custom field that contains spaces."""
     Asset.objects.create(
         manufacturer="Foo",

--- a/blueflow/tests/test_csv_custom_field.py
+++ b/blueflow/tests/test_csv_custom_field.py
@@ -1,6 +1,6 @@
 """Test CSV integration."""
 
-import os
+from pathlib import Path
 
 from blueflow.csv import process_csv
 from blueflow.models import Asset, AssetCustomField, AssetCustomFieldName
@@ -41,7 +41,7 @@ def test_process_csv_with_custom_field(setup_db):
         require_network_info=False,
         update_only=True,
     )
-    os.unlink(filename)
+    Path(filename).unlink()
     assert asset_custom_fields.count() == 1
 
     asset_custom_fields = AssetCustomField.objects.filter(asset=asset)
@@ -80,7 +80,7 @@ def test_process_csv_with_custom_field_underscores(setup_db):
         require_network_info=False,
         update_only=True,
     )
-    os.unlink(filename)
+    Path(filename).unlink()
 
     assert asset_custom_fields.count() == 1
     asset_custom_fields = AssetCustomField.objects.filter(asset=asset)
@@ -121,7 +121,7 @@ def test_process_csv_with_custom_field_spaces(setup_db):
         require_network_info=False,
         update_only=True,
     )
-    os.unlink(filename)
+    Path(filename).unlink()
 
     assert asset_custom_fields.count() == 1
     asset_custom_fields = AssetCustomField.objects.filter(asset=asset)

--- a/blueflow/tests/utils/__init__.py
+++ b/blueflow/tests/utils/__init__.py
@@ -1,13 +1,16 @@
 """test utilities."""
 
 import os
+import tempfile
+from pathlib import Path
 
 
 def path_nparent(path, n):
     """Return the n'th parent of path."""
+    p = Path(path)
     for _ in range(n):
-        path = os.path.dirname(path)
-    return path
+        p = p.parent
+    return p
 
 
 BLUEFLOW_HOME = path_nparent(__file__, 5)
@@ -28,6 +31,7 @@ def write_tempfile(text, bom_utf8=False):
         encoding = "utf-8-sig"
     else:
         encoding = None
-    with open(csvfd, "w", encoding=encoding) as fh:
+    os.close(csvfd)
+    with Path(filename).open("w", encoding=encoding) as fh:
         fh.write(text)
     return filename

--- a/blueflow/tests/utils/__init__.py
+++ b/blueflow/tests/utils/__init__.py
@@ -16,21 +16,18 @@ def path_nparent(path, n):
 BLUEFLOW_HOME = path_nparent(__file__, 5)
 
 
-def write_tempfile(text, bom_utf8=False):
+def write_tempfile(text, *, bom_utf8=False):
     """Write text (ostensibly, CSV) to a temp file and return the filename."""
     csvfd, filename = tempfile.mkstemp(suffix=".csv")
-    if bom_utf8:
-        # The 'utf-8-sig' special encoding inserts the byte order mark
-        # '0xef, 0xbb, 0xdf' at the beginning of the file (or strips it
-        # off, if it's there when reading.)
-        # NOTE: in general it is *discouraged* to use this BOM.  We use
-        # it here only to test that we're robust against it if it is in
-        # a file we come across.
-        #
-        # https://docs.python.org/3/library/codecs.html#encodings-and-unicode
-        encoding = "utf-8-sig"
-    else:
-        encoding = None
+    # The 'utf-8-sig' special encoding inserts the byte order mark
+    # '0xef, 0xbb, 0xdf' at the beginning of the file (or strips it
+    # off, if it's there when reading.)
+    # NOTE: in general it is *discouraged* to use this BOM.  We use
+    # it here only to test that we're robust against it if it is in
+    # a file we come across.
+    #
+    # https://docs.python.org/3/library/codecs.html#encodings-and-unicode
+    encoding = "utf-8-sig" if bom_utf8 else None
     os.close(csvfd)
     with Path(filename).open("w", encoding=encoding) as fh:
         fh.write(text)

--- a/blueflow/tests/utils/mssql_client_mock.py
+++ b/blueflow/tests/utils/mssql_client_mock.py
@@ -1,7 +1,9 @@
 """Utilities for creating a mock MSSQL Client."""
 
 import csv
+import os
 import tempfile
+from pathlib import Path
 
 
 def write_temp_csv(data, fieldnames):
@@ -12,7 +14,8 @@ def write_temp_csv(data, fieldnames):
     - fieldnames is a list of columns names for the CSV header row
     """
     csvfd, csvfilename = tempfile.mkstemp(suffix=".csv")
-    with open(csvfd, "w") as csvfile:
+    os.close(csvfd)
+    with Path(csvfilename).open("w") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         writer.writeheader()
         for row in data:


### PR DESCRIPTION
Resolves #130

> **chore** · complexity: **low** · branch: `chore/130-pathlib-migration`

## Summary

chore: migrate os.path / os.remove / open() to pathlib (PTH)

## Plan

1. **Add `from pathlib import Path` import; remove now-unused `import os`.**
   - File: `blueflow/csv/__init__.py`
   - Why: All four os.path / os.remove call sites in this module are being migrated, leaving `os` unused.
2. **Replace `with open(filename) as filehandle:` (line 90) with `with Path(filename).open() as filehandle:`.**
   - File: `blueflow/csv/__init__.py`
   - Why: PTH123 — plain string path in `linecount`, no fd or tight loop concerns.
3. **Replace `with open(filename, encoding="utf-8-sig") as csv_file:` (line 104) with `with Path(filename).open(encoding="utf-8-sig") as csv_file:`.**
   - File: `blueflow/csv/__init__.py`
   - Why: PTH123 — plain string path in `process_csv`.
4. **Replace `filename = os.path.join(django_settings.MEDIA_ROOT, ctx.ct.attachment.name)` (line 247) with `filename = Path(django_settings.MEDIA_ROOT) / ctx.ct.attachment.name`.**
   - File: `blueflow/csv/__init__.py`
   - Why: PTH118 — Path object propagates downstream to `Path.exists()`, `Path.unlink()`, and `process_csv`/`linecount` which both accept PathLike.
5. **Replace `if not os.path.exists(filename):` (line 252) with `if not filename.exists():` (filename is now a Path).**
   - File: `blueflow/csv/__init__.py`
   - Why: PTH110 — freshly-saved upload, no symlink concern; default `Path.exists()` semantics are correct.
6. **Replace `os.remove(filename)` (line 273) with `filename.unlink()` (no `missing_ok=True`).**
   - File: `blueflow/csv/__init__.py`
   - Why: PTH107 — preserve FileNotFoundError on missing temp file (per issue body's explicit guidance).
7. **Add `from pathlib import Path` import.**
   - File: `blueflow/management/commands/create_assets.py`
   - Why: Needed for the open() replacement.
8. **Replace `with open(file_path, encoding="utf-8") as file:` (line 49) with `with Path(file_path).open(encoding="utf-8") as file:`.**
   - File: `blueflow/management/commands/create_assets.py`
   - Why: PTH123 — plain string CLI argument.
9. **Replace `import os` with `from pathlib import Path` and rewrite `path_nparent` body to: `p = Path(path); for _ in range(n): p = p.parent; return p`.**
   - File: `blueflow/tests/utils/__init__.py`
   - Why: PTH120 — preserves loop structure; BLUEFLOW_HOME has zero consumers (verified), so return-type change from str to Path is safe.
10. **In `write_tempfile`, replace `with open(csvfd, "w", encoding=encoding) as fh:` (line 31) with `os.close(csvfd)` followed by `with Path(filename).open("w", encoding=encoding) as fh:`. Re-add `import os` (kept after step 9 swap) for `os.close`.**
   - File: `blueflow/tests/utils/__init__.py`
   - Why: PTH123 — open() was being given a file descriptor (issue body's escape hatch). Closing the fd then opening by path avoids leaking the fd while satisfying the lint rule.
11. **Add `import os` (for `os.close`) and `from pathlib import Path`. In `write_temp_csv`, replace `with open(csvfd, "w") as csvfile:` (line 15) with `os.close(csvfd)` followed by `with Path(csvfilename).open("w") as csvfile:`.**
   - File: `blueflow/tests/utils/mssql_client_mock.py`
   - Why: PTH123 — same fd-from-mkstemp pattern as tests/utils/__init__.py.
12. **Replace `import os` with `from pathlib import Path`. Convert each `open(filename, encoding="utf-8")` (lines 17, 27, 39) to `Path(filename).open(encoding="utf-8")` and each `os.unlink(filename)` (lines 19, 29, 41, 71, 102) to `Path(filename).unlink()` (no missing_ok).**
   - File: `blueflow/tests/test_csv_byte_order_mark.py`
   - Why: PTH123 x3 + PTH108 x5 — `filename` from `write_tempfile` is a plain string; preserve FileNotFoundError on cleanup.
13. **Replace `import os` with `from pathlib import Path`. Convert each `os.unlink(filename)` (lines 44, 83, 124) to `Path(filename).unlink()` (no missing_ok).**
   - File: `blueflow/tests/test_csv_custom_field.py`
   - Why: PTH108 x3 — same rationale as test_csv_byte_order_mark.

## Affected files

- `blueflow/csv/__init__.py`
- `blueflow/management/commands/create_assets.py`

## Acceptance criteria

- [ ] `uv run ruff check . --select PTH` exits 0 (all 20 violations resolved).
- [ ] `uv run ruff check .` and `uv run ruff format --check .` exit 0 — no new lint or format regressions.
- [ ] `uv run pytest blueflow/tests/test_csv_byte_order_mark.py blueflow/tests/test_csv_custom_field.py -v` shows the same pass/fail set as the documented baseline (no new failures).
- [ ] No `os.path`, `os.remove`, or `os.unlink` calls remain in the six edited files; `open()` only appears where a file descriptor is consumed (none, after the fd-refactor).
- [ ] `os.remove`/`os.unlink` translations use `Path.unlink()` without `missing_ok=True`, preserving FileNotFoundError semantics.
- [ ] Both fd-refactor sites (tests/utils/__init__.py and mssql_client_mock.py) call `os.close(csvfd)` before `Path.open()` so the mkstemp fd is not leaked.

## Risks

- If `MEDIA_ROOT` ever isn't a string (e.g., already a Path), `Path(Path(...)) / name` still works, so step 4 is safe; but a future caller relying on string concatenation behavior on `filename` could break. Verified all downstream consumers (`linecount`, `process_csv`, logger `%s`) accept PathLike.
- `path_nparent` return type changes from str to Path — verified zero consumers of `BLUEFLOW_HOME` exist, so this is safe today.
- `tempfile.mkstemp` opens the file in mode 'r+b'; closing the fd before reopening with mode 'w' truncates correctly and matches prior behavior. No race condition risk in tests since the temp filename is unique per call.
- Inadvertently adding `missing_ok=True` would silently swallow missing-file bugs (issue's main warning). Plan keeps default `unlink()` everywhere.

---

<details><summary>Raw plan (JSON)</summary>

```json
{
  "issue_number": 130,
  "issue_title": "chore: migrate os.path / os.remove / open() to pathlib (PTH)",
  "classification": "chore",
  "branch_name": "chore/130-pathlib-migration",
  "affected_files": [
    "blueflow/csv/__init__.py",
    "blueflow/management/commands/create_assets.py"
  ],
  "delete_files": [],
  "restricted_overrides": [
    {
      "path": "blueflow/tests/test_csv_byte_order_mark.py",
      "reason": "Contains 8 PTH violations (3x PTH123 open, 5x PTH108 os.unlink) that the issue explicitly scopes for migration."
    },
    {
      "path": "blueflow/tests/test_csv_custom_field.py",
      "reason": "Contains 3 PTH108 os.unlink violations that the issue explicitly scopes for migration."
    },
    {
      "path": "blueflow/tests/utils/__init__.py",
      "reason": "Contains PTH120 os.path.dirname and PTH123 open(fd) violations. The open() call passes a file descriptor and must be refactored (os.close then Path.open) \u2014 flagged in issue body as a behavioral gotcha."
    },
    {
      "path": "blueflow/tests/utils/mssql_client_mock.py",
      "reason": "Contains PTH123 open(fd) violation requiring the same os.close + Path.open refactor as tests/utils/__init__.py."
    }
  ],
  "plan_steps": [
    {
      "step": 1,
      "description": "Add `from pathlib import Path` import; remove now-unused `import os`.",
      "file": "blueflow/csv/__init__.py",
      "rationale": "All four os.path / os.remove call sites in this module are being migrated, leaving `os` unused."
    },
    {
      "step": 2,
      "description": "Replace `with open(filename) as filehandle:` (line 90) with `with Path(filename).open() as filehandle:`.",
      "file": "blueflow/csv/__init__.py",
      "rationale": "PTH123 \u2014 plain string path in `linecount`, no fd or tight loop concerns."
    },
    {
      "step": 3,
      "description": "Replace `with open(filename, encoding=\"utf-8-sig\") as csv_file:` (line 104) with `with Path(filename).open(encoding=\"utf-8-sig\") as csv_file:`.",
      "file": "blueflow/csv/__init__.py",
      "rationale": "PTH123 \u2014 plain string path in `process_csv`."
    },
    {
      "step": 4,
      "description": "Replace `filename = os.path.join(django_settings.MEDIA_ROOT, ctx.ct.attachment.name)` (line 247) with `filename = Path(django_settings.MEDIA_ROOT) / ctx.ct.attachment.name`.",
      "file": "blueflow/csv/__init__.py",
      "rationale": "PTH118 \u2014 Path object propagates downstream to `Path.exists()`, `Path.unlink()`, and `process_csv`/`linecount` which both accept PathLike."
    },
    {
      "step": 5,
      "description": "Replace `if not os.path.exists(filename):` (line 252) with `if not filename.exists():` (filename is now a Path).",
      "file": "blueflow/csv/__init__.py",
      "rationale": "PTH110 \u2014 freshly-saved upload, no symlink concern; default `Path.exists()` semantics are correct."
    },
    {
      "step": 6,
      "description": "Replace `os.remove(filename)` (line 273) with `filename.unlink()` (no `missing_ok=True`).",
      "file": "blueflow/csv/__init__.py",
      "rationale": "PTH107 \u2014 preserve FileNotFoundError on missing temp file (per issue body's explicit guidance)."
    },
    {
      "step": 7,
      "description": "Add `from pathlib import Path` import.",
      "file": "blueflow/management/commands/create_assets.py",
      "rationale": "Needed for the open() replacement."
    },
    {
      "step": 8,
      "description": "Replace `with open(file_path, encoding=\"utf-8\") as file:` (line 49) with `with Path(file_path).open(encoding=\"utf-8\") as file:`.",
      "file": "blueflow/management/commands/create_assets.py",
      "rationale": "PTH123 \u2014 plain string CLI argument."
    },
    {
      "step": 9,
      "description": "Replace `import os` with `from pathlib import Path` and rewrite `path_nparent` body to: `p = Path(path); for _ in range(n): p = p.parent; return p`.",
      "file": "blueflow/tests/utils/__init__.py",
      "rationale": "PTH120 \u2014 preserves loop structure; BLUEFLOW_HOME has zero consumers (verified), so return-type change from str to Path is safe."
    },
    {
      "step": 10,
      "description": "In `write_tempfile`, replace `with open(csvfd, \"w\", encoding=encoding) as fh:` (line 31) with `os.close(csvfd)` followed by `with Path(filename).open(\"w\", encoding=encoding) as fh:`. Re-add `import os` (kept after step 9 swap) for `os.close`.",
      "file": "blueflow/tests/utils/__init__.py",
      "rationale": "PTH123 \u2014 open() was being given a file descriptor (issue body's escape hatch). Closing the fd then opening by path avoids leaking the fd while satisfying the lint rule."
    },
    {
      "step": 11,
      "description": "Add `import os` (for `os.close`) and `from pathlib import Path`. In `write_temp_csv`, replace `with open(csvfd, \"w\") as csvfile:` (line 15) with `os.close(csvfd)` followed by `with Path(csvfilename).open(\"w\") as csvfile:`.",
      "file": "blueflow/tests/utils/mssql_client_mock.py",
      "rationale": "PTH123 \u2014 same fd-from-mkstemp pattern as tests/utils/__init__.py."
    },
    {
      "step": 12,
      "description": "Replace `import os` with `from pathlib import Path`. Convert each `open(filename, encoding=\"utf-8\")` (lines 17, 27, 39) to `Path(filename).open(encoding=\"utf-8\")` and each `os.unlink(filename)` (lines 19, 29, 41, 71, 102) to `Path(filename).unlink()` (no missing_ok).",
      "file": "blueflow/tests/test_csv_byte_order_mark.py",
      "rationale": "PTH123 x3 + PTH108 x5 \u2014 `filename` from `write_tempfile` is a plain string; preserve FileNotFoundError on cleanup."
    },
    {
      "step": 13,
      "description": "Replace `import os` with `from pathlib import Path`. Convert each `os.unlink(filename)` (lines 44, 83, 124) to `Path(filename).unlink()` (no missing_ok).",
      "file": "blueflow/tests/test_csv_custom_field.py",
      "rationale": "PTH108 x3 \u2014 same rationale as test_csv_byte_order_mark."
    }
  ],
  "risks": [
    "If `MEDIA_ROOT` ever isn't a string (e.g., already a Path), `Path(Path(...)) / name` still works, so step 4 is safe; but a future caller relying on string concatenation behavior on `filename` could break. Verified all downstream consumers (`linecount`, `process_csv`, logger `%s`) accept PathLike.",
    "`path_nparent` return type changes from str to Path \u2014 verified zero consumers of `BLUEFLOW_HOME` exist, so this is safe today.",
    "`tempfile.mkstemp` opens the file in mode 'r+b'; closing the fd before reopening with mode 'w' truncates correctly and matches prior behavior. No race condition risk in tests since the temp filename is unique per call.",
    "Inadvertently adding `missing_ok=True` would silently swallow missing-file bugs (issue's main warning). Plan keeps default `unlink()` everywhere."
  ],
  "acceptance_criteria": [
    "`uv run ruff check . --select PTH` exits 0 (all 20 violations resolved).",
    "`uv run ruff check .` and `uv run ruff format --check .` exit 0 \u2014 no new lint or format regressions.",
    "`uv run pytest blueflow/tests/test_csv_byte_order_mark.py blueflow/tests/test_csv_custom_field.py -v` shows the same pass/fail set as the documented baseline (no new failures).",
    "No `os.path`, `os.remove`, or `os.unlink` calls remain in the six edited files; `open()` only appears where a file descriptor is consumed (none, after the fd-refactor).",
    "`os.remove`/`os.unlink` translations use `Path.unlink()` without `missing_ok=True`, preserving FileNotFoundError semantics.",
    "Both fd-refactor sites (tests/utils/__init__.py and mssql_client_mock.py) call `os.close(csvfd)` before `Path.open()` so the mkstemp fd is not leaked."
  ],
  "estimated_complexity": "low"
}
```

</details>