### PR TITLE
feat(api): add Scalar UI for /api/docs

### DIFF
--- a/blueflow/scalar_viewer.py
+++ b/blueflow/scalar_viewer.py
@@ -1,0 +1,44 @@
+"""Scalar API Reference HTML shell for OpenAPI documentation.
+
+Loads the browser bundle from jsDelivr and points at the Spectacular schema
+served at ``/api/schema/``. See https://scalar.com/products/api-references/
+"""
+
+from django.http import HttpRequest, HttpResponse
+
+# Pin for reproducible UI; bump intentionally when upgrading Scalar.
+_SCALAR_API_REFERENCE_JS = (
+    "https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.55.3/dist/browser/"
+    "standalone.js"
+)
+
+_OPENAPI_RELATIVE_URL = "/api/schema/"
+_PAGE_TITLE = "BlueFlow REST API"
+
+
+def scalar_viewer(_request: HttpRequest) -> HttpResponse:
+    """Return a minimal HTML page that embeds Scalar against our OpenAPI schema."""
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>{_PAGE_TITLE}</title>
+  <style>
+    body {{ margin: 0; padding: 0; }}
+  </style>
+</head>
+<body>
+  <noscript>
+    Scalar requires JavaScript to browse the API reference.
+  </noscript>
+  <script
+    id="api-reference"
+    data-url="{_OPENAPI_RELATIVE_URL}"
+    data-proxy-url=""
+  ></script>
+  <script src="{_SCALAR_API_REFERENCE_JS}"></script>
+</body>
+</html>
+"""
+    return HttpResponse(html.encode("utf-8"), content_type="text/html; charset=utf-8")

--- a/blueflow/urls.py
+++ b/blueflow/urls.py
@@ -4,13 +4,12 @@ app_name = "blueflow"
 
 from django.conf.urls import include
 from django.urls import path
-from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from drf_spectacular.views import SpectacularAPIView
 from rest_framework.authtoken import views as authview
 from rest_framework.routers import DefaultRouter
 
 from . import views
-
-API_TITLE = "BlueFlow REST API"
+from .scalar_viewer import scalar_viewer
 
 router = DefaultRouter()
 # Regular BlueFlow Models
@@ -38,11 +37,7 @@ router.register(r"viper", views.ViperViewSet, basename="viper")
 
 urlpatterns = [
     path("schema/", SpectacularAPIView.as_view(), name="schema"),
-    path(
-        "docs/",
-        SpectacularSwaggerView.as_view(url_name="blueflow:schema"),
-        name="swagger-ui",
-    ),
+    path("docs/", scalar_viewer, name="api-docs"),
     path(r"api-token-auth/", authview.obtain_auth_token, name="auth-token"),
     path("", include(router.urls)),
 ]


### PR DESCRIPTION
## Summary

- Cherry-picks fuzz's standalone Scalar viewer commit (`9acc3f7`) from PR #150 onto develop so the new `/api/docs/` experience can land independently of the in-flight `open_ports_tcp` work on that branch.
- `/api/schema/` is unchanged (still `SpectacularAPIView`); only the viewer at `/api/docs/` swaps from Swagger to Scalar.
- Route name renamed from `swagger-ui` to `api-docs`.

## Context

PR #150 (`chore/prune-api`) bundles three workstreams: Scalar viewer, `@extend_schema(exclude=True)` curation of the rendered surface, and asset `open_ports_tcp` constraints. Pulling the viewer forward unblocks docs work without waiting for the rest. Authorship preserved via cherry-pick.

## Open questions for the author

- CDN: the Scalar bundle loads from `cdn.jsdelivr.net` at view time. Worth vendoring under `static/` if any demo environment is air-gapped.
- Route name change (`swagger-ui` → `api-docs`): any consumer project reverse-routing the old name?
- Whether the surface-trim commit (`941fad9`) should follow here in a separate PR, or stay on #150.

## Test plan

- [ ] `uv run python project/manage.py check` (passes locally)
- [ ] Open `/api/docs/` in a browser — Scalar reference renders against `/api/schema/`
- [ ] `/api/schema/` output byte-identical to develop's
- [ ] Search consumer projects for `reverse("blueflow:swagger-ui")` references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed API documentation interface now available at `/docs/`. The updated viewer provides enhanced navigation and improved usability for exploring endpoints, reviewing schemas, and testing API requests with ease.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/virtalabs/blueflow/pull/151)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->