### PR TITLE
feat(api): add Usage stub field to AssetSerializer

### DIFF
--- a/blueflow/tests/test_asset_usage.py
+++ b/blueflow/tests/test_asset_usage.py
@@ -28,6 +28,7 @@ def test_asset_usage_stub_emits_empty_hour_dicts(auth_client):
     """Stub usage returns an empty hour dict at every weekday index."""
     asset = models.Asset.objects.create(hostname="usage-empty.example.com")
     response = auth_client.get(f"/api/assets/{asset.id}/")
+    assert response.status_code == status.HTTP_200_OK
     body = response.json()
     for index, hours in enumerate(body["usage"]):
         assert hours == {}, f"index {index} should be empty in stub (got {hours!r})"

--- a/blueflow/tests/test_asset_usage.py
+++ b/blueflow/tests/test_asset_usage.py
@@ -1,35 +1,33 @@
-"""Tests for the Asset.usage serializer field (contract-level stub)."""
+"""Tests for the Asset.usage serializer field (contract-level stub).
+
+The usage field is a 7-element array indexed by Python's datetime.weekday()
+convention: 0=Monday, 1=Tuesday, 2=Wednesday, 3=Thursday, 4=Friday,
+5=Saturday, 6=Sunday.
+"""
 
 from rest_framework import status
 
 from blueflow import models
 
+DAYS_IN_WEEK = 7
+
 
 def test_asset_response_includes_usage_field(auth_client):
-    """Each asset response includes a usage field with all seven weekdays."""
+    """Each asset response includes a usage field as a 7-element array."""
     asset = models.Asset.objects.create(hostname="usage-test.example.com")
     response = auth_client.get(f"/api/assets/{asset.id}/")
     assert response.status_code == status.HTTP_200_OK
 
     body = response.json()
     assert "usage" in body
-
-    expected_days = {
-        "sunday",
-        "monday",
-        "tuesday",
-        "wednesday",
-        "thursday",
-        "friday",
-        "saturday",
-    }
-    assert set(body["usage"].keys()) == expected_days
+    assert isinstance(body["usage"], list)
+    assert len(body["usage"]) == DAYS_IN_WEEK
 
 
 def test_asset_usage_stub_emits_empty_hour_dicts(auth_client):
-    """Stub usage returns empty hour dicts for every weekday."""
+    """Stub usage returns an empty hour dict at every weekday index."""
     asset = models.Asset.objects.create(hostname="usage-empty.example.com")
     response = auth_client.get(f"/api/assets/{asset.id}/")
     body = response.json()
-    for day, hours in body["usage"].items():
-        assert hours == {}, f"{day} should be empty dict in stub (got {hours!r})"
+    for index, hours in enumerate(body["usage"]):
+        assert hours == {}, f"index {index} should be empty in stub (got {hours!r})"

--- a/blueflow/tests/test_asset_usage.py
+++ b/blueflow/tests/test_asset_usage.py
@@ -1,0 +1,35 @@
+"""Tests for the Asset.usage serializer field (contract-level stub)."""
+
+from rest_framework import status
+
+from blueflow import models
+
+
+def test_asset_response_includes_usage_field(auth_client):
+    """Each asset response includes a usage field with all seven weekdays."""
+    asset = models.Asset.objects.create(hostname="usage-test.example.com")
+    response = auth_client.get(f"/api/assets/{asset.id}/")
+    assert response.status_code == status.HTTP_200_OK
+
+    body = response.json()
+    assert "usage" in body
+
+    expected_days = {
+        "sunday",
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+    }
+    assert set(body["usage"].keys()) == expected_days
+
+
+def test_asset_usage_stub_emits_empty_hour_dicts(auth_client):
+    """Stub usage returns empty hour dicts for every weekday."""
+    asset = models.Asset.objects.create(hostname="usage-empty.example.com")
+    response = auth_client.get(f"/api/assets/{asset.id}/")
+    body = response.json()
+    for day, hours in body["usage"].items():
+        assert hours == {}, f"{day} should be empty dict in stub (got {hours!r})"

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -13,7 +13,7 @@ from django.db.models import Case, Count, QuerySet, When
 from django.db.models.aggregates import Func
 from django.db.utils import IntegrityError
 from django.utils import timezone
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, extend_schema_field
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
@@ -115,6 +115,26 @@ class AssetUpsertSerializer(serializers.Serializer):
         return sorted(set(ports_list))
 
 
+class UsageSerializer(serializers.Serializer):
+    """Asset usage pattern by weekday and hour.
+
+    Each weekday maps to a dict of hour (0-23, as JSON string keys) to
+    observation count. Hours with zero observations are omitted from
+    the response. Today's implementation is a contract-only stub
+    returning empty hour dicts for every weekday; the backing model
+    and aggregation logic (time scope, time zone, what counts as a
+    "use") are deferred to a follow-up issue.
+    """
+
+    sunday = serializers.DictField(child=serializers.IntegerField(min_value=0))
+    monday = serializers.DictField(child=serializers.IntegerField(min_value=0))
+    tuesday = serializers.DictField(child=serializers.IntegerField(min_value=0))
+    wednesday = serializers.DictField(child=serializers.IntegerField(min_value=0))
+    thursday = serializers.DictField(child=serializers.IntegerField(min_value=0))
+    friday = serializers.DictField(child=serializers.IntegerField(min_value=0))
+    saturday = serializers.DictField(child=serializers.IntegerField(min_value=0))
+
+
 class AssetSerializer(serializers.HyperlinkedModelSerializer):
     """Serializes assets.
 
@@ -140,6 +160,15 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
     last_updated = serializers.DateTimeField(read_only=True, allow_null=True)
 
+    usage = serializers.SerializerMethodField(
+        help_text=(
+            "Usage pattern by weekday and hour. Each weekday maps to a "
+            "dict of hour (0-23) to observation count; hours with zero "
+            "observations are omitted. Stub today — backing model and "
+            "aggregation logic to be implemented in a follow-up."
+        ),
+    )
+
     class Meta:
         """Wire this serializer to a model."""
 
@@ -157,6 +186,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
             "last_updated",
             "asset_tags",
             "asset_vulnerabilities",
+            "usage",
         )
 
         fields = asset_fields + computed_fields
@@ -180,6 +210,21 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
     def validate_open_ports_tcp(self, ports_list: list[int]) -> list[int]:
         """Deduplicate and sort ports."""
         return sorted(set(ports_list))
+
+    @extend_schema_field(UsageSerializer)
+    def get_usage(self, _obj):
+        return {
+            day: {}
+            for day in (
+                "sunday",
+                "monday",
+                "tuesday",
+                "wednesday",
+                "thursday",
+                "friday",
+                "saturday",
+            )
+        }
 
 
 class HistoricalAssetSerializer(serializers.HyperlinkedModelSerializer):

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -115,24 +115,29 @@ class AssetUpsertSerializer(serializers.Serializer):
         return sorted(set(ports_list))
 
 
-class UsageSerializer(serializers.Serializer):
-    """Asset usage pattern by weekday and hour.
-
-    Each weekday maps to a dict of hour (0-23, as JSON string keys) to
-    observation count. Hours with zero observations are omitted from
-    the response. Today's implementation is a contract-only stub
-    returning empty hour dicts for every weekday; the backing model
-    and aggregation logic (time scope, time zone, what counts as a
-    "use") are deferred to a follow-up issue.
-    """
-
-    sunday = serializers.DictField(child=serializers.IntegerField(min_value=0))
-    monday = serializers.DictField(child=serializers.IntegerField(min_value=0))
-    tuesday = serializers.DictField(child=serializers.IntegerField(min_value=0))
-    wednesday = serializers.DictField(child=serializers.IntegerField(min_value=0))
-    thursday = serializers.DictField(child=serializers.IntegerField(min_value=0))
-    friday = serializers.DictField(child=serializers.IntegerField(min_value=0))
-    saturday = serializers.DictField(child=serializers.IntegerField(min_value=0))
+# Usage field schema. Index follows Python's datetime.weekday() / ISO 8601:
+# 0=Monday, 1=Tuesday, 2=Wednesday, 3=Thursday, 4=Friday, 5=Saturday, 6=Sunday.
+# Each entry maps hour-of-day (0-23, JSON-string-coerced) to non-negative count.
+# Hours with zero observations are omitted. The schema is inlined here (rather
+# than a named Usage component) because it's small and used in exactly one place.
+_USAGE_FIELD_SCHEMA = {
+    "type": "array",
+    "minItems": 7,
+    "maxItems": 7,
+    "items": {
+        "type": "object",
+        "additionalProperties": {"type": "integer", "minimum": 0},
+    },
+    "example": [
+        {"9": 1, "10": 12, "11": 8, "14": 3, "15": 5},  # 0 = Monday
+        {"9": 1, "10": 8, "11": 15},                    # 1 = Tuesday
+        {"9": 2, "14": 5},                              # 2 = Wednesday
+        {"10": 6, "11": 9, "13": 4},                    # 3 = Thursday
+        {"9": 1, "13": 2},                              # 4 = Friday
+        {},                                             # 5 = Saturday
+        {},                                             # 6 = Sunday
+    ],
+}
 
 
 class AssetSerializer(serializers.HyperlinkedModelSerializer):
@@ -162,10 +167,13 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
     usage = serializers.SerializerMethodField(
         help_text=(
-            "Usage pattern by weekday and hour. Each weekday maps to a "
-            "dict of hour (0-23) to observation count; hours with zero "
-            "observations are omitted. Stub today — backing model and "
-            "aggregation logic to be implemented in a follow-up."
+            "Usage pattern: 7-element array of hour-of-day to observation-count "
+            "maps. Index is 0-based with Monday first — 0=Monday, 1=Tuesday, "
+            "2=Wednesday, 3=Thursday, 4=Friday, 5=Saturday, 6=Sunday. Hour keys "
+            "are JSON-string-coerced integers 0-23; counts are non-negative; "
+            "hours with zero observations are omitted from the response. Stub "
+            "today — backing model and aggregation logic to be implemented in "
+            "a follow-up."
         ),
     )
 
@@ -211,20 +219,9 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
         """Deduplicate and sort ports."""
         return sorted(set(ports_list))
 
-    @extend_schema_field(UsageSerializer)
+    @extend_schema_field(_USAGE_FIELD_SCHEMA)
     def get_usage(self, _obj):
-        return {
-            day: {}
-            for day in (
-                "sunday",
-                "monday",
-                "tuesday",
-                "wednesday",
-                "thursday",
-                "friday",
-                "saturday",
-            )
-        }
+        return [{} for _ in range(7)]
 
 
 class HistoricalAssetSerializer(serializers.HyperlinkedModelSerializer):


### PR DESCRIPTION
## Summary

Adds a `usage` field on `AssetSerializer` representing per-asset hourly observation counts by weekday.

Wire shape: **7-element array** of `{hour: count}` maps, indexed by `datetime.weekday()` (0=Monday ... 6=Sunday). Contract-only stub returning `[{} for _ in range(7)]`; backing model and aggregation logic are deferred to a follow-up. Two passing tests cover shape and stub content.

## Wire-format decision: 7-element array vs dict-of-weekday-names

The first commit (`a005415`) shaped this as `{"sunday": {...}, "monday": {...}, ...}`. The second commit (`cb05408`) switches to a 7-element array indexed Monday-first.

| Aspect | Dict-of-names | Array (chosen) |
|---|---|---|
| Bytes on wire | extra weekday-name strings | smaller |
| Length guarantee | "7 named keys required" | `minItems/maxItems = 7` |
| Iteration ergonomics | `Object.entries(usage)` | `usage.forEach((d, i) => ...)` |
| Visualization use case | needs manual day-order array | direct array passthrough |
| Hardcoded day lookup | `usage.monday` (self-explanatory) | `usage[1]` (convention required) |
| Server-side bucketing | weekday-name table lookup | `usage[obs.timestamp.weekday()]` |

Picked the array shape because the dominant consumer pattern is iterating all seven days for visualization, not named-day lookup. The index convention (0=Monday ... 6=Sunday) matches Python's `datetime.weekday()`, so server-side aggregation is trivial when the backing model lands. The convention is documented in the field's `help_text` (consumer-facing in OpenAPI) and a block comment above the schema constant (developer-facing).

## Inner schema: approaches tried in this PR

The inner per-weekday object (hour-key → count) has three viable schema shapes. We loaded `/api/docs/` and looked at how Scalar rendered each.

### `additionalProperties` (final choice)

```json
{ "type": "object", "additionalProperties": { "type": "integer", "minimum": 0 } }
```

Scalar's render of the inner object:

```
additionalProperty
Type: integer
min: 0
```

`additionalProperty` is Scalar's invented placeholder key for "any property allowed." Confusing on first read but unambiguous once you know JSON Schema's `additionalProperties` convention.

### `patternProperties` (tried, reverted)

```json
{
  "type": "object",
  "patternProperties": { "^([0-9]|1[0-9]|2[0-3])$": { "type": "integer", "minimum": 0 } },
  "additionalProperties": false
}
```

Scalar render:

```
^([0-9]|1[0-9]|2[0-3])$
Type: integer
min: 0
```

The regex shows literally as the "property name." Worse than `additionalProperties` for human readability, and `patternProperties` is officially an OpenAPI 3.1 feature — spectacular emits 3.0.3, so it's effectively a non-standard extension that Scalar doesn't enrich.

### Explicit 24 named hour properties (tried, reverted)

```python
"properties": {str(h): {"type": "integer", "minimum": 0} for h in range(24)},
"additionalProperties": false
```

Scalar render: 24 explicit rows labeled `0` through `23`, each "type integer, min 0." Most documentation-correct but visually noisy at 24 rows per weekday in the property panel.

### Decision

Reverted to `additionalProperties`. None of the three render with full clarity in Scalar, so the canonical contract documentation is the **field description** + **populated example** — both deliberately rich so they carry the contract independent of how Scalar chooses to render the schema shape.

## Scalar rendering limitations encountered

Captured for future API work in this codebase:

1. **`required`-array order is not preserved in display.** drf-spectacular sorts `required` alphabetically in `plumbing.py:331` (hardcoded, no settings flag). Tried a `POSTPROCESSING_HOOKS` postprocessor to override; the YAML output came out in declaration order but Scalar's UI render did not change — Scalar applies its own sort/display logic on top of the spec. Abandoned.
2. **Map-shaped schemas (`additionalProperties`) render with an `additionalProperty` placeholder key.** Common JSON Schema convention; renderer-side limitation we live with.
3. **`patternProperties` regex shows literally** as the property name in Scalar's panel. No richer rendering.
4. **`OpenApiExample` / `extend_schema_serializer(examples=[...])` don't attach to nested serializers** reached via `extend_schema_field` on a `SerializerMethodField`. Component-level `example` injection requires `OpenApiSerializerExtension` (idiomatic, mirrors the existing netfields extensions in `blueflow/spectacular.py`) or a postprocessing hook (escape hatch).

Common theme: drf-spectacular and DRF are model-first frameworks; the contract-first workflow we'd ideally want here is achievable but requires manual spectacular plumbing per endpoint. Genuine API-first design in this stack remains a friction-heavy path.

## Known follow-ups (not in this PR)

- Backing model for usage observations (likely a through-table or time-series row per `(asset, weekday, hour)` bucket).
- Time scope decision (all-time aggregate, rolling window, etc.).
- Time zone interpretation for `weekday()` / `hour` calculations.
- Definition of "use" — current spec is "probably one packet in any 5-minute window," not pinned.

## Test plan

- [x] Automated: `uv run pytest blueflow/tests/test_asset_usage.py` — 2 tests pass (shape + stub content)
- [x] Full suite: no regression vs develop baseline (run earlier in iteration)
- [x] Verified `/api/docs/` renders the populated example and index convention in the description
- [x] Manual sanity-check from a reviewer's machine

Toward the asset usage feature; backing model and aggregation in a follow-up issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset API now includes a new "usage" field: a 7-element array (Monday→Sunday) where each day holds hourly usage counts (hours 0–23).
  * Initial responses currently return empty per-day entries as a stub.

* **Tests**
  * Added contract tests verifying the asset GET response includes a 7-element usage list and that stubbed entries are empty.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/virtalabs/blueflow/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->