### PR TITLE
fix(viper): align integrationUpload payload with Viper OpenAPI (#160)

### DIFF
--- a/blueflow/celery/tests/test_viper.py
+++ b/blueflow/celery/tests/test_viper.py
@@ -75,9 +75,12 @@ def test_viper_webhook_output_with_all_assets(celery_app, setup_assets):
             payload = call.kwargs["json"]
             assert payload["page"] == 1 + i
             assert payload["page_size"] == page_size
-            assert payload["total"] == total_assets
+            assert payload["total_count"] == total_assets
             assert payload["total_pages"] == total_pages
-            assert payload["request_id"] == request_id
+            # request_id, since, before are internal — not on the wire
+            assert "request_id" not in payload
+            assert "since" not in payload
+            assert "before" not in payload
 
             # urls should only be none at the first and last pages, respectively
             args = [
@@ -89,21 +92,26 @@ def test_viper_webhook_output_with_all_assets(celery_app, setup_assets):
                 "before",
             ]
 
-            previous = payload["previous_page"]
+            previous = payload["previous"]
             if i > 0:
                 _assert_page_query(previous, args, not_args)
             else:
                 assert previous is None
 
-            _next = payload["next_page"]
+            _next = payload["next"]
             if i + 1 < total_pages:
                 _assert_page_query(_next, args, not_args)
             else:
                 assert _next is None
 
 
-def test_viper_asset_optional_fields_default_empty(celery_app, setup_assets):
-    """Cpe and role are not yet populated — assert they default to empty strings."""
+def test_viper_asset_optional_fields_always_present(celery_app, setup_assets):
+    """Per Viper docs, cpe/role aren't nullable — they always ship as strings.
+
+    cpe is always ``""`` until BlueFlow has a CPE source; role mirrors
+    ``asset.category`` (string, possibly empty). Both keys must be present
+    on every item.
+    """
     with patch("blueflow.celery.tasks.requests.post") as mock_post:
         viper_webhook.apply(
             args=[
@@ -119,8 +127,8 @@ def test_viper_asset_optional_fields_default_empty(celery_app, setup_assets):
         )
     for call in mock_post.call_args_list:
         for item in call.kwargs["json"]["items"]:
-            assert "cpe" not in item
-            assert "role" not in item
+            assert item["cpe"] == ""
+            assert isinstance(item["role"], str)
 
 
 @pytest.fixture
@@ -241,5 +249,5 @@ def test_viper_webhook_includes_assets_without_last_pinged(celery_app):
         "Asset with last_pinged=None was not forwarded to Viper"
     )
     payload = mock_post.call_args.kwargs["json"]
-    assert payload["total"] == 1
+    assert payload["total_count"] == 1
     assert len(payload["items"]) == 1

--- a/blueflow/models/viper.py
+++ b/blueflow/models/viper.py
@@ -194,7 +194,9 @@ class ViperWebhookResponseList:
         request_id: str = "",
     ) -> Generator[ViperWebhookResponse, None, None]:
         Asset = apps.get_model("blueflow", "Asset")
-        assets = Asset.objects.filter(modified__gte=request.since)
+        assets = Asset.objects.filter(modified__gte=request.since).prefetch_related(
+            "usage",
+        )
         if request.before:
             assets = assets.filter(modified__lte=request.before)
         assets = assets.order_by("modified").all()

--- a/blueflow/models/viper.py
+++ b/blueflow/models/viper.py
@@ -66,57 +66,61 @@ class ViperWebhookRequest:
         return base
 
 
+def _project_usage(asset: Asset) -> list[dict[str, int]]:
+    """Project an asset's Usage rows into Viper's utilization shape.
+
+    Monday-first length-7 list of {str(hour): count} dicts; zero-count hours
+    stripped. Mirrors ``AssetSerializer.get_usage`` so both integrations agree
+    on the wire shape.
+    """
+    days: list[dict[str, int]] = [{} for _ in range(7)]
+    for usage in asset.usage.all():
+        bucket = days[usage.day_of_week]
+        for hour in range(24):
+            count = getattr(usage, f"hour_{hour:02d}")
+            if count > 0:
+                bucket[str(hour)] = count
+    return days
+
+
 @dataclass
 class ViperAsset:
     """Data for a viper asset."""
 
-    id: int
+    ip: str
     network_segment: str
     cpe: str
     role: str
-    upstream_api: str  # asset endpoint url: {BASE_URL}/api/assets/{id}/
+    upstream_api: str
     hostname: str
     mac_address: str
     serial_number: str
     location: dict[str, str]
     status: str
-    vendorID: str  # noqa: N815
+    vendor_id: str
+    utilization: list[dict[str, int]]
 
     def __init__(self, asset: Asset):
-        self.id = asset.id
-        self.name = asset.name
-        self.ip_address = asset.ip_address
-        self.mac_address = str(asset.mac_address)
-        self.vendor = asset.manufacturer
-        self.model = asset.model
-        self.serial_number = asset.serial_number
-        self.udi = asset.udi
+        self.ip = str(asset.ip_address) if asset.ip_address else ""
         self.network_segment = (
             ""  # TODO(taylorcochran): get network segment from asset.network_qset()
         )
         self.cpe = ""  # TODO(taylorcochran): get cpe from asset.cpe_qset()
-        self.role = ""
-        self.upstream_api = ""
+        self.role = str(asset.category) if asset.category else ""
+        self.upstream_api = f"{settings.BASE_URL}/api/assets/{asset.id}/"
         self.hostname = asset.hostname or ""
         # Coerce to str so payload is JSON-serializable
         # (Asset uses netaddr.EUI / InetAddress)
         self.mac_address = str(asset.mac_address) if asset.mac_address else ""
         self.serial_number = asset.serial_number or ""
-        self.location = {}  # TODO(taylorcochran): custom fields?
-        self.status = "active"  # TODO(taylorcochran): how do we want to determine this?
-        self.vendorID = str(asset.nic_vendor)
+        self.location = {"facility": "", "building": "", "floor": "", "room": ""}
+        self.status = "Active"
+        self.vendor_id = str(asset.nic_vendor) if asset.nic_vendor else ""
+        self.utilization = _project_usage(asset)
 
     def to_dict(self):
         """Return a JSON-serializable dict (for json.dumps or requests)."""
-        # there are differences between python's concept of Optional and
-        # a potentially optional key in a restful blob
-        # exclude optional keys when their values are falsey
-        base = asdict(self)
-        optional = ["cpe", "role"]
-        for key in optional:
-            if not base[key]:
-                del base[key]
-        return base
+        return asdict(self)
 
 
 @dataclass
@@ -126,7 +130,7 @@ class ViperWebhookResponse:
     items: list[ViperAsset]
     page: int
     page_size: int
-    total: int
+    total_count: int
     total_pages: int
     since: datetime | str
     request_id: str = ""
@@ -134,42 +138,52 @@ class ViperWebhookResponse:
     # settings?
     webhook_path: str = "/api/viper/webhook/"
 
+    # Keys held on the dataclass for internal use (URL generation, retry
+    # bookkeeping) but stripped before the payload goes on the wire to Viper.
+    _INTERNAL_KEYS: ClassVar[tuple[str, ...]] = (
+        "since",
+        "before",
+        "request_id",
+        "webhook_path",
+    )
+
     def to_dict(self):
         """Return a JSON-serializable dict (for json.dumps or requests)."""
         base = asdict(self)
+        for key in self._INTERNAL_KEYS:
+            base.pop(key, None)
         base["items"] = [item.to_dict() for item in self.items]
-        base["next_page"] = self.next_page
-        base["previous_page"] = self.previous_page
-        base["since"] = _to_iso(self.since)
-        base["before"] = _to_iso(self.before)
+        base["next"] = self.next
+        base["previous"] = self.previous
         return base
 
     def _gen_page(self, page: int) -> str:
         """Generate a page URL for on the page number, page size, and last sync time."""
-        params = f"page={page}&page_size={self.page_size}&since={self.since}"
+        since = _to_iso(self.since)
+        params = f"page={page}&page_size={self.page_size}&since={since}"
         if self.before:
-            params += f"&before={self.before}"
+            params += f"&before={_to_iso(self.before)}"
         return f"{settings.BASE_URL}{self.webhook_path}?{params}"
 
     @property
-    def next_page(self) -> str | None:
+    def next(self) -> str | None:
         """Return the URL to the next page."""
         if self.page >= self.total_pages:
             return None
-        if hasattr(self, "_next_page"):
-            return self._next_page
-        self._next_page = self._gen_page(self.page + 1)
-        return self._next_page
+        if hasattr(self, "_next"):
+            return self._next
+        self._next = self._gen_page(self.page + 1)
+        return self._next
 
     @property
-    def previous_page(self) -> str | None:
+    def previous(self) -> str | None:
         """Return the URL to the previous page."""
         if self.page <= 1:
             return None
-        if hasattr(self, "_previous_page"):
-            return self._previous_page
-        self._previous_page = self._gen_page(self.page - 1)
-        return self._previous_page
+        if hasattr(self, "_previous"):
+            return self._previous
+        self._previous = self._gen_page(self.page - 1)
+        return self._previous
 
 
 @dataclass
@@ -184,8 +198,8 @@ class ViperWebhookResponseList:
         if request.before:
             assets = assets.filter(modified__lte=request.before)
         assets = assets.order_by("modified").all()
-        total = assets.count()
-        total_pages = math.ceil(total / request.page_size)
+        total_count = assets.count()
+        total_pages = math.ceil(total_count / request.page_size)
         page = 1
         for i in range(0, len(assets), request.page_size):
             if page > request.max_pages:
@@ -196,7 +210,7 @@ class ViperWebhookResponseList:
                 items=assets_chunk,
                 page=page,
                 page_size=request.page_size,
-                total=total,
+                total_count=total_count,
                 total_pages=total_pages,
                 since=request.since,
                 before=request.before,

--- a/blueflow/tests/test_asset.py
+++ b/blueflow/tests/test_asset.py
@@ -1073,7 +1073,7 @@ def test_asset_date_range(
         assert res.data["count"] == num_assets
 
 
-def test_external_key_non_connector(db) -> None:
+def test_external_key_non_connector() -> None:
     """Test that external_keys JSON field accepts arbitrary key-value pairs."""
     foobar = models.Asset.objects.create(name="Foobar")
     foobar.external_keys = {"ECN": "12345"}

--- a/blueflow/tests/test_asset_hostname.py
+++ b/blueflow/tests/test_asset_hostname.py
@@ -152,34 +152,34 @@ def test_upsert_without_hostname_does_not_check_conflicts(
 # direct scanner code) gets blocked.
 
 
-def test_db_rejects_duplicate_hostname(db) -> None:  # noqa: ARG001
+def test_db_rejects_duplicate_hostname(db) -> None:
     """The unique index on Asset.hostname blocks duplicates at the DB layer."""
     models.Asset.objects.create(hostname="foo.example")
     with pytest.raises(IntegrityError), transaction.atomic():
         models.Asset.objects.create(hostname="foo.example")
 
 
-def test_db_allows_multiple_null_hostnames(db) -> None:  # noqa: ARG001
+def test_db_allows_multiple_null_hostnames(db) -> None:
     """Postgres treats NULLs as distinct in unique indexes; NULL rows coexist."""
     a = models.Asset.objects.create(hostname=None)
     b = models.Asset.objects.create(hostname=None)
     assert a.id != b.id
 
 
-def test_db_rejects_empty_hostname_on_insert(db) -> None:  # noqa: ARG001
+def test_db_rejects_empty_hostname_on_insert(db) -> None:
     """The CheckConstraint blocks empty-string hostnames at insert time."""
     with pytest.raises(IntegrityError), transaction.atomic():
         models.Asset.objects.create(hostname="")
 
 
-def test_db_rejects_empty_hostname_on_update(db) -> None:  # noqa: ARG001
+def test_db_rejects_empty_hostname_on_update(db) -> None:
     """CheckConstraint also catches UPDATEs (e.g. QuerySet.update bypassing save)."""
     asset = models.Asset.objects.create(hostname="foo.example")
     with pytest.raises(IntegrityError), transaction.atomic():
         models.Asset.objects.filter(pk=asset.pk).update(hostname="")
 
 
-def test_db_constraint_error_includes_constraint_name(db) -> None:  # noqa: ARG001
+def test_db_constraint_error_includes_constraint_name(db) -> None:
     """The constraint name is part of the public contract; renames must update tests."""
     with pytest.raises(IntegrityError) as exc_info, transaction.atomic():
         models.Asset.objects.create(hostname="")

--- a/blueflow/tests/test_asset_hostname.py
+++ b/blueflow/tests/test_asset_hostname.py
@@ -152,34 +152,34 @@ def test_upsert_without_hostname_does_not_check_conflicts(
 # direct scanner code) gets blocked.
 
 
-def test_db_rejects_duplicate_hostname(db) -> None:
+def test_db_rejects_duplicate_hostname() -> None:
     """The unique index on Asset.hostname blocks duplicates at the DB layer."""
     models.Asset.objects.create(hostname="foo.example")
     with pytest.raises(IntegrityError), transaction.atomic():
         models.Asset.objects.create(hostname="foo.example")
 
 
-def test_db_allows_multiple_null_hostnames(db) -> None:
+def test_db_allows_multiple_null_hostnames() -> None:
     """Postgres treats NULLs as distinct in unique indexes; NULL rows coexist."""
     a = models.Asset.objects.create(hostname=None)
     b = models.Asset.objects.create(hostname=None)
     assert a.id != b.id
 
 
-def test_db_rejects_empty_hostname_on_insert(db) -> None:
+def test_db_rejects_empty_hostname_on_insert() -> None:
     """The CheckConstraint blocks empty-string hostnames at insert time."""
     with pytest.raises(IntegrityError), transaction.atomic():
         models.Asset.objects.create(hostname="")
 
 
-def test_db_rejects_empty_hostname_on_update(db) -> None:
+def test_db_rejects_empty_hostname_on_update() -> None:
     """CheckConstraint also catches UPDATEs (e.g. QuerySet.update bypassing save)."""
     asset = models.Asset.objects.create(hostname="foo.example")
     with pytest.raises(IntegrityError), transaction.atomic():
         models.Asset.objects.filter(pk=asset.pk).update(hostname="")
 
 
-def test_db_constraint_error_includes_constraint_name(db) -> None:
+def test_db_constraint_error_includes_constraint_name() -> None:
     """The constraint name is part of the public contract; renames must update tests."""
     with pytest.raises(IntegrityError) as exc_info, transaction.atomic():
         models.Asset.objects.create(hostname="")

--- a/blueflow/tests/test_csv_byte_order_mark.py
+++ b/blueflow/tests/test_csv_byte_order_mark.py
@@ -44,7 +44,7 @@ def test_tempfile_auto_bom():
     assert csv[1:] == csv_orig
 
 
-def test_process_csv_without_bom(setup_db):  # noqa: ARG001
+def test_process_csv_without_bom(setup_db):
     """We can import from a CSV file that doesn't contains the BOM mark."""
     Asset.objects.create(
         manufacturer="Foo",
@@ -74,7 +74,7 @@ def test_process_csv_without_bom(setup_db):  # noqa: ARG001
     assert asset.manufacturer == "Bar"
 
 
-def test_process_csv_with_bom(setup_db):  # noqa: ARG001
+def test_process_csv_with_bom(setup_db):
     """We can import from a CSV file that contains the BOM mark."""
     Asset.objects.create(
         manufacturer="Foo",

--- a/blueflow/tests/test_csv_custom_field.py
+++ b/blueflow/tests/test_csv_custom_field.py
@@ -9,7 +9,7 @@ from blueflow.tests.utils import write_tempfile
 from .test_csv import TestCTX
 
 
-def test_process_csv_with_custom_field(setup_db):  # noqa: ARG001
+def test_process_csv_with_custom_field(setup_db):
     """We can import from CSV into a custom field.
 
     Similar to test above but lower level (more unit test)
@@ -50,7 +50,7 @@ def test_process_csv_with_custom_field(setup_db):  # noqa: ARG001
     assert asset_shininess == "Very shiny"
 
 
-def test_process_csv_with_custom_field_underscores(setup_db):  # noqa: ARG001
+def test_process_csv_with_custom_field_underscores(setup_db):
     """We can import from CSV into a custom field that contains underscores."""
     Asset.objects.create(
         manufacturer="Foo",
@@ -91,7 +91,7 @@ def test_process_csv_with_custom_field_underscores(setup_db):  # noqa: ARG001
     assert asset_site_description == "Very shiny"
 
 
-def test_process_csv_with_custom_field_spaces(setup_db):  # noqa: ARG001
+def test_process_csv_with_custom_field_spaces(setup_db):
     """We can import from CSV into a custom field that contains spaces."""
     Asset.objects.create(
         manufacturer="Foo",

--- a/blueflow/tests/test_upsert.py
+++ b/blueflow/tests/test_upsert.py
@@ -98,7 +98,7 @@ def test_upsert_token_auth(token_auth_client: APIClient) -> None:
 
 
 @pytest.mark.skip(reason="Blueflow uses AllowAny; auth enforced by consuming product")
-def test_upsert_unauth_403(db: None, enable_core_switch: None) -> None:
+def test_upsert_unauth_403(enable_core_switch: None) -> None:
     """PUT unauthenticated would assert 403 if IsAuthenticated were enforced."""
     client = APIClient()
     response = client.put(
@@ -170,7 +170,7 @@ def test_get_asset_after_upsert_404(asset_edit_client: APIClient) -> None:
 
 
 @pytest.mark.skip(reason="Blueflow uses AllowAny; auth enforced by consuming product")
-def test_get_asset_after_upsert_unauth_403(db: None, enable_core_switch: None) -> None:
+def test_get_asset_after_upsert_unauth_403(enable_core_switch: None) -> None:
     """GET without auth would assert 403 if IsAuthenticated were enforced."""
     asset = models.Asset.objects.create(mac_address="aa:bb:cc:dd:ee:ff")
     client = APIClient()

--- a/blueflow/tests/test_upsert.py
+++ b/blueflow/tests/test_upsert.py
@@ -98,7 +98,7 @@ def test_upsert_token_auth(token_auth_client: APIClient) -> None:
 
 
 @pytest.mark.skip(reason="Blueflow uses AllowAny; auth enforced by consuming product")
-def test_upsert_unauth_403(db: None, enable_core_switch: None) -> None:  # noqa: ARG001
+def test_upsert_unauth_403(db: None, enable_core_switch: None) -> None:
     """PUT unauthenticated would assert 403 if IsAuthenticated were enforced."""
     client = APIClient()
     response = client.put(
@@ -170,7 +170,7 @@ def test_get_asset_after_upsert_404(asset_edit_client: APIClient) -> None:
 
 
 @pytest.mark.skip(reason="Blueflow uses AllowAny; auth enforced by consuming product")
-def test_get_asset_after_upsert_unauth_403(db: None, enable_core_switch: None) -> None:  # noqa: ARG001
+def test_get_asset_after_upsert_unauth_403(db: None, enable_core_switch: None) -> None:
     """GET without auth would assert 403 if IsAuthenticated were enforced."""
     asset = models.Asset.objects.create(mac_address="aa:bb:cc:dd:ee:ff")
     client = APIClient()
@@ -278,9 +278,7 @@ def test_upsert_modern_field_names(asset_edit_client: APIClient) -> None:
 
 def test_upsert_no_deprecation_header(asset_edit_client: APIClient) -> None:
     """PUT response does not include Deprecation header."""
-    response = _put_upsert(
-        asset_edit_client, {"mac_address": "11:22:33:44:55:66"}
-    )
+    response = _put_upsert(asset_edit_client, {"mac_address": "11:22:33:44:55:66"})
     assert response.status_code == status.HTTP_201_CREATED
     assert "Deprecation" not in response
     assert "Link" not in response
@@ -332,7 +330,10 @@ def test_upsert_open_ports_normalized(asset_edit_client: APIClient) -> None:
     """PUT with duplicate/unsorted ports stores them deduplicated and sorted."""
     response = _put_upsert(
         asset_edit_client,
-        {"mac_address": "11:22:33:44:55:66", "open_ports_tcp": [443, 80, 443, 8080, 80]},
+        {
+            "mac_address": "11:22:33:44:55:66",
+            "open_ports_tcp": [443, 80, 443, 8080, 80],
+        },
     )
     assert response.status_code == status.HTTP_201_CREATED
     assert response.data["open_ports_tcp"] == [80, 443, 8080]

--- a/blueflow/tests/test_viper_models.py
+++ b/blueflow/tests/test_viper_models.py
@@ -1,0 +1,240 @@
+"""Unit tests for the Viper integration dataclasses (#160).
+
+These tests drive the schema-alignment work: they exercise
+``ViperAsset.to_dict()`` and ``ViperWebhookResponse.to_dict()`` directly,
+without going through Celery or HTTP, so failures point straight at the
+serialization shape.
+
+Wire-level behaviour (what gets POSTed to Viper) is covered separately in
+``blueflow/celery/tests/test_viper.py``.
+"""
+
+from django.conf import settings
+
+from blueflow import models
+from blueflow.models.viper import ViperAsset, ViperWebhookResponse
+
+DAYS_IN_WEEK = 7
+SAMPLE_HOUR_23_COUNT = 5
+SAMPLE_TOTAL_COUNT = 42
+
+
+def _make_asset(**overrides) -> models.Asset:
+    defaults = {
+        "hostname": "viper-schema-test.example.com",
+        "ip_address": "10.0.0.5",
+        "mac_address": "00:11:22:33:44:55",
+    }
+    defaults.update(overrides)
+    return models.Asset.objects.create(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# ViperAsset
+# ---------------------------------------------------------------------------
+
+
+def test_viper_asset_to_dict_includes_required_keys():
+    """Viper's OpenAPI marks ip, upstream_api, vendor_id as required."""
+    asset = _make_asset()
+    payload = ViperAsset(asset).to_dict()
+    for key in ("ip", "upstream_api", "vendor_id"):
+        assert key in payload, f"required key {key!r} missing from payload"
+
+
+def test_viper_asset_to_dict_drops_blueflow_internal_id():
+    """BlueFlow's integer PK is not part of Viper's schema; must not leak."""
+    asset = _make_asset()
+    payload = ViperAsset(asset).to_dict()
+    assert "id" not in payload
+
+
+def test_viper_asset_status_literal_is_capitalized_active():
+    """Viper's status enum is Active|Decommissioned|Maintenance — capital A."""
+    asset = _make_asset()
+    payload = ViperAsset(asset).to_dict()
+    assert payload["status"] == "Active"
+
+
+def test_viper_asset_role_is_populated_from_category():
+    """Role maps to asset.category, not a hardcoded blank."""
+    asset = _make_asset(category="infusion-pump")
+    payload = ViperAsset(asset).to_dict()
+    assert payload["role"] == "infusion-pump"
+
+
+def test_viper_asset_role_is_empty_string_when_category_unset():
+    """Role falls back to empty string (not pruned) when no category."""
+    asset = _make_asset(category=None)
+    payload = ViperAsset(asset).to_dict()
+    assert payload["role"] == ""
+
+
+def test_viper_asset_upstream_api_uses_base_url_and_asset_id():
+    """upstream_api points back at the asset's BlueFlow detail URL."""
+    asset = _make_asset()
+    payload = ViperAsset(asset).to_dict()
+    expected = f"{settings.BASE_URL}/api/assets/{asset.id}/"
+    assert payload["upstream_api"] == expected
+
+
+def test_viper_asset_ip_comes_from_asset_ip_address():
+    """Ip is the asset's ip_address as a string."""
+    asset = _make_asset(ip_address="192.168.50.10")
+    payload = ViperAsset(asset).to_dict()
+    assert payload["ip"] == "192.168.50.10"
+
+
+def test_viper_asset_ip_is_empty_string_when_no_address():
+    """Ip falls back to empty string when ip_address is null."""
+    asset = _make_asset(ip_address=None)
+    payload = ViperAsset(asset).to_dict()
+    assert payload["ip"] == ""
+
+
+def test_viper_asset_location_has_four_string_keys():
+    """Location is the {facility, building, floor, room} object, not {}."""
+    asset = _make_asset()
+    payload = ViperAsset(asset).to_dict()
+    location = payload["location"]
+    assert set(location.keys()) == {"facility", "building", "floor", "room"}
+    for value in location.values():
+        assert value == ""
+
+
+def test_viper_asset_cpe_is_present_even_when_empty():
+    """Cpe stays in the payload as '' (not nullable per Viper docs)."""
+    asset = _make_asset()
+    payload = ViperAsset(asset).to_dict()
+    assert payload["cpe"] == ""
+
+
+def test_viper_asset_utilization_is_length_seven_list():
+    """Utilization is a 7-element array (Monday=0..Sunday=6)."""
+    asset = _make_asset()
+    payload = ViperAsset(asset).to_dict()
+    assert isinstance(payload["utilization"], list)
+    assert len(payload["utilization"]) == DAYS_IN_WEEK
+
+
+def test_viper_asset_utilization_with_no_usage_rows_is_seven_empty_dicts():
+    """An asset with no Usage rows serialises 7 empty dicts."""
+    asset = _make_asset()
+    payload = ViperAsset(asset).to_dict()
+    assert payload["utilization"] == [{}, {}, {}, {}, {}, {}, {}]
+
+
+def test_viper_asset_utilization_excludes_zero_count_hours():
+    """Hours with count==0 are omitted from each day's dict."""
+    asset = _make_asset()
+    models.Usage.objects.create(
+        asset=asset,
+        day_of_week=models.DayOfWeek.WEDNESDAY,
+        hour_09=3,
+        hour_10=0,
+        hour_14=2,
+    )
+    payload = ViperAsset(asset).to_dict()
+    wednesday = payload["utilization"][models.DayOfWeek.WEDNESDAY]
+    assert wednesday == {"9": 3, "14": 2}
+
+
+def test_viper_asset_utilization_uses_string_hour_keys():
+    """Hour keys are stringified ints (JSON requires string keys anyway)."""
+    asset = _make_asset()
+    models.Usage.objects.create(
+        asset=asset,
+        day_of_week=models.DayOfWeek.MONDAY,
+        hour_00=1,
+        hour_23=SAMPLE_HOUR_23_COUNT,
+    )
+    payload = ViperAsset(asset).to_dict()
+    monday = payload["utilization"][models.DayOfWeek.MONDAY]
+    assert "0" in monday
+    assert "23" in monday
+    assert monday["0"] == 1
+    assert monday["23"] == SAMPLE_HOUR_23_COUNT
+
+
+# ---------------------------------------------------------------------------
+# ViperWebhookResponse
+# ---------------------------------------------------------------------------
+
+
+def _make_response(**overrides) -> ViperWebhookResponse:
+    defaults = {
+        "items": [],
+        "page": 1,
+        "page_size": 10,
+        "total_count": 0,
+        "total_pages": 1,
+        "since": "2026-01-01T00:00:00Z",
+        "before": None,
+        "request_id": "req-abc",
+    }
+    defaults.update(overrides)
+    return ViperWebhookResponse(**defaults)
+
+
+def test_response_uses_total_count_key_not_total():
+    """Wrapper renames: total → total_count."""
+    response = _make_response(total_count=SAMPLE_TOTAL_COUNT)
+    payload = response.to_dict()
+    assert "total_count" in payload
+    assert payload["total_count"] == SAMPLE_TOTAL_COUNT
+    assert "total" not in payload
+
+
+def test_response_uses_next_and_previous_keys_not_page_suffixed():
+    """Wrapper renames: next_page → next, previous_page → previous."""
+    response = _make_response(page=2, total_count=30, total_pages=3)
+    payload = response.to_dict()
+    assert "next" in payload
+    assert "previous" in payload
+    assert "next_page" not in payload
+    assert "previous_page" not in payload
+
+
+def test_response_first_page_has_null_previous():
+    """Previous is None on page 1."""
+    response = _make_response(page=1, total_count=30, total_pages=3)
+    payload = response.to_dict()
+    assert payload["previous"] is None
+
+
+def test_response_last_page_has_null_next():
+    """Next is None on the final page."""
+    response = _make_response(page=3, total_count=30, total_pages=3)
+    payload = response.to_dict()
+    assert payload["next"] is None
+
+
+def test_response_drops_internal_only_fields():
+    """since, before, request_id, webhook_path are internal — not on the wire."""
+    response = _make_response(
+        since="2026-01-01T00:00:00Z",
+        before="2026-01-02T00:00:00Z",
+        request_id="req-xyz",
+    )
+    payload = response.to_dict()
+    for key in ("since", "before", "request_id", "webhook_path"):
+        assert key not in payload, f"internal field {key!r} leaked to the wire"
+
+
+def test_response_emits_items_key_not_assets():
+    """The list key is items, not assets."""
+    response = _make_response()
+    payload = response.to_dict()
+    assert "items" in payload
+    assert "assets" not in payload
+
+
+def test_response_serializes_items_via_viper_asset_to_dict():
+    """Items in the wrapper are ViperAsset.to_dict() outputs, not dataclass dumps."""
+    asset = _make_asset()
+    response = _make_response(items=[ViperAsset(asset)], total_count=1)
+    payload = response.to_dict()
+    assert len(payload["items"]) == 1
+    item = payload["items"][0]
+    assert "ip" in item
+    assert "id" not in item

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,13 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"**/tests/**" = ["S101"]
-"tests/**" = ["S101"]
+# S101: assert is fine in tests.
+# ARG001: pytest fixtures are declared via argument list; the body doesn't
+#         read them (they run for side effects like configuring celery or
+#         loading fixture data), so ruff's "unused argument" check is a
+#         false positive in test contexts.
+"**/tests/**" = ["S101", "ARG001"]
+"tests/**" = ["S101", "ARG001"]
 "conftest.py" = ["S101"]
 "harness/**" = ["T201", "S603", "S607", "PLR0913"]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,7 @@
 """Tests for blueflow models (mirrors blueflow/models)."""
 
 
-def test_asset_model(db):
+def test_asset_model():
     """Smoke test: Asset can be created."""
     from blueflow.models import Asset
 
@@ -9,7 +9,7 @@ def test_asset_model(db):
     assert asset.pk is not None
     assert Asset.objects.filter(pk=asset.pk).exists()
 
-def test_tag_model(db):
+def test_tag_model():
     """Smoke test: Tag model exists and has expected attributes."""
     from blueflow.models import Tag
 


### PR DESCRIPTION
## Summary

Fixes #160. Aligns BlueFlow's outbound `integrationUpload` payload with Viper's actual OpenAPI schema so pages stop coming back as `400`.

**`ViperAsset`**
- Add `ip` (from `asset.ip_address`) and `utilization` (projected from `Usage` rows in the Monday-first sparse `{hour: count}` shape).
- Populate `upstream_api` from `BASE_URL + asset.id` (was `""`); `role` from `asset.category` (was `""`).
- Status literal: `"active"` → `"Active"` (Viper enum is `Active | Decommissioned | Maintenance`).
- Expand `location` from `{}` to `{facility, building, floor, room}` with empty-string defaults (not nullable per Viper docs).
- Rename `vendorID` → `vendor_id`.
- Drop BlueFlow's PK `id` from the payload (strict schema rejects extras).
- Stop pruning `cpe`/`role` — both ship as `""` when unset.

**`ViperWebhookResponse`**
- Wrapper renames: `total` → `total_count`, `next_page`/`previous_page` properties → `next`/`previous`.
- Internal-only fields (`since`, `before`, `request_id`, `webhook_path`) are kept on the dataclass for URL generation but stripped from `to_dict()` output via a new `_INTERNAL_KEYS` ClassVar.

**Tests**
- New `blueflow/tests/test_viper_models.py` — 21 unit tests on `ViperAsset.to_dict()` and `ViperWebhookResponse.to_dict()` covering required keys, dropped extras, status enum, utilization projection, role-from-category mapping, upstream URL pattern, IP fallback, location shape, and all wrapper renames.
- Updated existing `blueflow/celery/tests/test_viper.py` assertions to reflect the new wire shape (`total_count`, `next`, `previous`, internal fields stripped).

## Drive-by lint/cleanup commits

- **`chore(lint): exempt ARG001 in test files`** — pytest fixtures are declared via the test function's argument list and their value is the side effect, not the return; ruff's "unused argument" rule is a false positive in test contexts. Centralizes the exemption in `pyproject.toml` and removes 6 now-redundant `# noqa: ARG001` pragmas across 4 unrelated test files. ruff-format also reflowed two pre-existing call sites in `test_upsert.py`.
- **`chore(tests): drop redundant db arg from test functions`** — the autouse `_auto_db` fixture in the root `conftest.py` already enables DB access for every test, so declaring `db` as a function argument is dead weight. Removes the arg from 10 test functions across 4 files. Verified by stash-and-rerun: pre-change and post-change runs of the touched files report the same 26 baseline failures and 3 baseline lints (no new errors introduced).

## Decisions worth flagging

- **`max_pages=1 × page_size=500` ceiling** — Viper's inbound webhook currently sends those values, so any hospital with >500 assets will silently lose the tail. Out of scope here, but worth a follow-up issue or a Viper-side bump.
- **`status` mapping** — hardcoded `"Active"`. BlueFlow has no status concept today (no `Asset.status` field, no tag convention). When one lands, swap the literal for a mapping; not building a one-branch helper now.
- **`location` shape** — empty strings on all four sub-keys until a BlueFlow source (custom fields? tags?) is decided.
- **Casing converter (`pageSize`, `totalCount`, etc.)** — not in this PR. The plan is that snake_case will be handled at serialize/`requests`-lib time. The casing converter needs to be scoped to the outbound view only — applying it globally would silently break the inbound webhook parser, which uses snake_case (`max_pages`, `page_size`).

## Test plan

- [x] `uv run pytest blueflow/tests/test_viper_models.py blueflow/celery/tests/test_viper.py blueflow/views/tests/test_viper.py blueflow/tests/test_asset_usage.py` → 43/43 green on a fresh DB
- [x] Stash-and-rerun comparison on the 4 files touched by the `db` sweep — same 26 baseline failures and 3 baseline lints before/after; no regressions
- [x] `just boot && just capture && just integrate` against `demo-0.3.1` with the `init/blueflow-patches/tasks.py` overlay **unmounted** — no `400` from Viper, `just check viper` matches `just check blueflow`
- [ ] Confirm casing converter strategy (separate PR) before merging into `demo-0.3.2`

Closes #160.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Viper webhook payloads no longer leak internal request fields.
  * Asset optional fields (`cpe`, `role`) are now always present with proper defaults.

* **New Features**
  * Asset utilization data now included in Viper webhook payloads.
  * Improved pagination fields in webhook responses (`total_count`, `next`, `previous`).

* **Tests**
  * Added comprehensive test suite for Viper integration models.
  * Refactored test fixtures across multiple test modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/virtalabs/blueflow/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->