### PR TITLE
bug/category to viper role

### DIFF
--- a/blueflow/celery/tasks.py
+++ b/blueflow/celery/tasks.py
@@ -21,7 +21,7 @@ class Task(BaseTask):
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         logger.error("[!!] %s failed: %s", task_id, exc)
 
-def _send_viper_payload(viper_data: ViperWebhookJob, request_id: str) -> None:
+def _send_viper_payload(viper_data: ViperWebhookRequest, request_id: str) -> None:
     """Send viper payload, logging partial errors.
 
     We may want to consider logging partial errors and attempting to

--- a/blueflow/celery/tests/test_viper.py
+++ b/blueflow/celery/tests/test_viper.py
@@ -74,9 +74,9 @@ def test_viper_webhook_output_with_all_assets(celery_app, setup_assets):
         for i, call in enumerate(mock_post.call_args_list):
             payload = call.kwargs["json"]
             assert payload["page"] == 1 + i
-            assert payload["page_size"] == page_size
-            assert payload["total_count"] == total_assets
-            assert payload["total_pages"] == total_pages
+            assert payload["pageSize"] == page_size
+            assert payload["totalCount"] == total_assets
+            assert payload["totalPages"] == total_pages
             # request_id, since, before are internal — not on the wire
             assert "request_id" not in payload
             assert "since" not in payload
@@ -105,13 +105,8 @@ def test_viper_webhook_output_with_all_assets(celery_app, setup_assets):
                 assert _next is None
 
 
-def test_viper_asset_optional_fields_always_present(celery_app, setup_assets):
-    """Per Viper docs, cpe/role aren't nullable — they always ship as strings.
-
-    cpe is always ``""`` until BlueFlow has a CPE source; role mirrors
-    ``asset.category`` (string, possibly empty). Both keys must be present
-    on every item.
-    """
+def test_viper_asset_wire_shape_uses_camel_case(celery_app, setup_assets):
+    """integrationUpload items use camelCase keys per Viper OpenAPI."""
     with patch("blueflow.celery.tasks.requests.post") as mock_post:
         viper_webhook.apply(
             args=[
@@ -126,9 +121,13 @@ def test_viper_asset_optional_fields_always_present(celery_app, setup_assets):
             ]
         )
     for call in mock_post.call_args_list:
-        for item in call.kwargs["json"]["items"]:
-            assert item["cpe"] == ""
-            assert isinstance(item["role"], str)
+        body = call.kwargs["json"]
+        assert "pageSize" in body
+        assert "totalCount" in body
+        for item in body["items"]:
+            assert "upstreamApi" in item
+            assert "vendorId" in item
+            assert "upstream_api" not in item
 
 
 @pytest.fixture
@@ -249,5 +248,5 @@ def test_viper_webhook_includes_assets_without_last_pinged(celery_app):
         "Asset with last_pinged=None was not forwarded to Viper"
     )
     payload = mock_post.call_args.kwargs["json"]
-    assert payload["total_count"] == 1
+    assert payload["totalCount"] == 1
     assert len(payload["items"]) == 1

--- a/blueflow/models/viper.py
+++ b/blueflow/models/viper.py
@@ -115,12 +115,39 @@ class ViperAsset:
         self.serial_number = asset.serial_number or ""
         self.location = {"facility": "", "building": "", "floor": "", "room": ""}
         self.status = "Active"
-        self.vendor_id = str(asset.nic_vendor) if asset.nic_vendor else ""
+        self.vendor_id = str(asset.manufacturer or "")
         self.utilization = _project_usage(asset)
 
-    def to_dict(self):
-        """Return a JSON-serializable dict (for json.dumps or requests)."""
-        return asdict(self)
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable dict for Viper integrationUpload.
+
+        Uses camelCase keys per Viper's ``assetInputSchema``.  ``role`` is
+        omitted when ``Asset.category`` is unset — Viper treats empty strings
+        as invalid (``.min(1)``) and stores null.  ``vendorId`` is
+        ``Asset.manufacturer`` (TapirXL ``vendor`` → BlueFlow manufacturer).
+        """
+        out: dict = {
+            "ip": self.ip,
+            "upstreamApi": self.upstream_api,
+            "vendorId": self.vendor_id,
+            "status": self.status,
+            "utilization": self.utilization,
+        }
+        if self.hostname:
+            out["hostname"] = self.hostname
+        if self.mac_address:
+            out["macAddress"] = self.mac_address
+        if self.serial_number:
+            out["serialNumber"] = self.serial_number
+        if self.network_segment:
+            out["networkSegment"] = self.network_segment
+        if self.cpe:
+            out["cpe"] = self.cpe
+        if self.role:
+            out["role"] = self.role
+        if any(self.location.values()):
+            out["location"] = self.location
+        return out
 
 
 @dataclass
@@ -147,15 +174,17 @@ class ViperWebhookResponse:
         "webhook_path",
     )
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         """Return a JSON-serializable dict (for json.dumps or requests)."""
-        base = asdict(self)
-        for key in self._INTERNAL_KEYS:
-            base.pop(key, None)
-        base["items"] = [item.to_dict() for item in self.items]
-        base["next"] = self.next
-        base["previous"] = self.previous
-        return base
+        return {
+            "items": [item.to_dict() for item in self.items],
+            "page": self.page,
+            "pageSize": self.page_size,
+            "totalCount": self.total_count,
+            "totalPages": self.total_pages,
+            "next": self.next,
+            "previous": self.previous,
+        }
 
     def _gen_page(self, page: int) -> str:
         """Generate a page URL for on the page number, page size, and last sync time."""

--- a/blueflow/tests/fixtures/tapirxl_telemetry.jsonl
+++ b/blueflow/tests/fixtures/tapirxl_telemetry.jsonl
@@ -1,0 +1,8 @@
+{"hostname":"CCPLATFORM01","ip_address":"10.10.20.20","mac_address":"00:09:5C:BB:CC:02","vendor":"microsoft","product":"windows_10","version":null,"device_class":"workstation","open_ports":[5355],"confidence":"HIGH"}
+{"hostname":"MX700-bed12","ip_address":"10.10.10.21","mac_address":"00:09:FB:BD:75:6D","vendor":"philips","product":"intellivue_mx700","version":null,"device_class":"patient_monitor","open_ports":[3702],"confidence":"LOW"}
+{"hostname":null,"ip_address":"10.10.20.1","mac_address":"00:1B:17:00:01:11","vendor":"paloaltonetworks","product":"pan_os","version":null,"device_class":"firewall","open_ports":[],"confidence":"LOW"}
+{"hostname":"PACSARCH01","ip_address":"10.10.20.30","mac_address":"00:50:56:8B:CA:FE","vendor":"microsoft","product":"windows_server","version":null,"device_class":"server","open_ports":[5355],"confidence":"LOW"}
+{"hostname":null,"ip_address":"10.10.20.7","mac_address":"00:50:56:8B:DC:01","vendor":"vmware","product":null,"version":null,"device_class":null,"open_ports":[],"confidence":"LOW"}
+{"hostname":"BRILL-CT01","ip_address":"10.10.10.30","mac_address":"00:90:20:AA:BB:01","vendor":"philips","product":"brilliance_ict","version":null,"device_class":null,"open_ports":[],"confidence":"HIGH"}
+{"hostname":"ACMEWS02","ip_address":"10.10.10.41","mac_address":"60:A5:E2:AE:32:1A","vendor":"microsoft","product":"windows_10","version":null,"device_class":"workstation","open_ports":[5355],"confidence":"LOW"}
+{"hostname":"ACMECT01","ip_address":"10.10.10.40","mac_address":"E8:D8:D1:AA:BB:02","vendor":"microsoft","product":"windows_7","version":null,"device_class":"workstation","open_ports":[5355],"confidence":"LOW"}

--- a/blueflow/tests/test_tapirxl_viper_regression.py
+++ b/blueflow/tests/test_tapirxl_viper_regression.py
@@ -63,10 +63,6 @@ def _vrl_transform(record: dict) -> dict:
 
     Mirrors the strict outbound shape of ``configs/upload-vector.vrl``:
     only declared fields are included; any unmapped source key is dropped.
-
-    Note: ``app_sw_version`` is included here (``version`` in the source) to
-    accurately mirror the VRL, even though ``AssetUpsertSerializer`` does not
-    yet declare it — the serializer silently drops unknown fields.
     """
     out: dict = {}
 
@@ -165,6 +161,26 @@ def test_vrl_transform_golden_categorised_records(record: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_device_class_alias_persisted_through_upsert(asset_edit_client) -> None:
+    """Raw TapirXL device_class field maps to category when Vector is bypassed."""
+    from blueflow import models
+
+    resp = asset_edit_client.put(
+        "/api/assets/upsert/",
+        json.dumps(
+            {
+                "mac_address": "DE:AD:BE:EF:00:01",
+                "ip_address": "10.10.10.99",
+                "device_class": "patient_monitor",
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    asset = models.Asset.objects.get(mac_address="de:ad:be:ef:00:01")
+    assert asset.category == "patient_monitor"
+
+
 def test_device_class_persisted_through_upsert(asset_edit_client) -> None:
     """category from VRL transform survives PUT /api/assets/upsert/ → Asset.category."""
     from blueflow import models
@@ -191,6 +207,35 @@ def test_device_class_persisted_through_upsert(asset_edit_client) -> None:
     assert resp.status_code == 201
     asset = models.Asset.objects.get(mac_address="00:09:fb:bd:75:6d")
     assert asset.category == "patient_monitor"
+
+
+def test_version_persisted_through_upsert(asset_edit_client) -> None:
+    """app_sw_version from VRL transform survives PUT /api/assets/upsert/ → Asset.app_sw_version."""
+    from blueflow import models
+
+    payload = _vrl_transform(
+        {
+            "mac_address": "AA:BB:CC:DD:EE:FF",
+            "ip_address": "10.0.0.1",
+            "hostname": None,
+            "vendor": None,
+            "product": None,
+            "version": "1.2.3",
+            "device_class": None,
+            "open_ports": [],
+            "confidence": None,
+        }
+    )
+    assert payload.get("app_sw_version") == "1.2.3"
+
+    resp = asset_edit_client.put(
+        "/api/assets/upsert/",
+        json.dumps(payload),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    asset = models.Asset.objects.get(mac_address="aa:bb:cc:dd:ee:ff")
+    assert asset.app_sw_version == "1.2.3"
 
 
 # ---------------------------------------------------------------------------
@@ -248,13 +293,20 @@ def test_golden_device_class_propagates_to_viper_role(
         for call in mock_post.call_args_list
         for item in call.kwargs["json"]["items"]
     ]
-    role_by_ip: dict[str, str] = {item["ip"]: item["role"] for item in all_items}
+    role_by_ip: dict[str, str | None] = {
+        item["ip"]: item.get("role") for item in all_items
+    }
 
     # Phase 3 — assert role == device_class for every golden record
     for record in records:
         ip = record["ip_address"]
-        expected = record["device_class"] or ""
+        expected = record["device_class"]
         assert ip in role_by_ip, f"{ip} missing from Viper output"
-        assert role_by_ip[ip] == expected, (
-            f"{ip}: expected role={expected!r}, got role={role_by_ip[ip]!r}"
-        )
+        if expected:
+            assert role_by_ip[ip] == expected, (
+                f"{ip}: expected role={expected!r}, got role={role_by_ip[ip]!r}"
+            )
+        else:
+            assert role_by_ip[ip] is None, (
+                f"{ip}: expected role omitted, got role={role_by_ip[ip]!r}"
+            )

--- a/blueflow/tests/test_tapirxl_viper_regression.py
+++ b/blueflow/tests/test_tapirxl_viper_regression.py
@@ -1,0 +1,260 @@
+"""Regression: TapirXL telemetry → upsert → Viper role propagation.
+
+Drives the full pipeline with golden data from
+  .cursor/context/tapirxl_telemetry.jsonl  (TapirXL InventoryRecord wire format)
+
+through the VRL field-mapping logic (mirrored as ``_vrl_transform`` below),
+through ``PUT /api/assets/upsert/``, and verifies that the resulting
+``ViperWebhookResponse`` items carry the correct ``role`` value.
+
+Three test layers, cheapest first:
+  1. ``_vrl_transform`` unit tests — validate the Python mirror of the VRL.
+  2. Single-record persistence test — ``category`` survives the upsert.
+  3. Full-pipeline regression — all 8 golden records → upsert → Viper ``role``.
+
+If ``configs/upload-vector.vrl`` (in the TapirXL repo) changes its field
+mapping, ``_VENDOR_DISPLAY``, ``_PRODUCT_DISPLAY``, and ``_vrl_transform``
+below must be updated to match.
+"""
+
+import json
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from blueflow.models.viper import ViperWebhookRequest, ViperWebhookResponseList
+
+# ---------------------------------------------------------------------------
+# Golden data
+# ---------------------------------------------------------------------------
+
+# Sourced from the TapirXL repo's golden_synthetic_philips_inventory.jsonl;
+# update this file when TapirXL's golden set changes.
+_GOLDEN_JSONL = Path(__file__).parent / "fixtures" / "tapirxl_telemetry.jsonl"
+
+# ---------------------------------------------------------------------------
+# Python mirror of configs/upload-vector.vrl (TapirXL repo)
+# Keep in sync with that file.
+# ---------------------------------------------------------------------------
+
+_VENDOR_DISPLAY: dict[str, str] = {
+    "intel": "Intel",
+    "microsoft": "Microsoft",
+    "paloaltonetworks": "Palo Alto Networks",
+    "philips": "Philips",
+    "vmware": "VMware",
+}
+
+_PRODUCT_DISPLAY: dict[str, str] = {
+    "brilliance_ict": "Brilliance iCT",
+    "clinical_collaboration_platform": "Clinical Collaboration Platform",
+    "intellivue_mx700": "IntelliVue MX700",
+    "pan_os": "PAN-OS",
+    "windows_10": "Windows 10",
+    "windows_7": "Windows 7",
+    "windows_server": "Windows Server",
+}
+
+
+def _vrl_transform(record: dict) -> dict:
+    """Produce a BlueFlow upsert payload from a TapirXL InventoryRecord.
+
+    Mirrors the strict outbound shape of ``configs/upload-vector.vrl``:
+    only declared fields are included; any unmapped source key is dropped.
+
+    Note: ``app_sw_version`` is included here (``version`` in the source) to
+    accurately mirror the VRL, even though ``AssetUpsertSerializer`` does not
+    yet declare it — the serializer silently drops unknown fields.
+    """
+    out: dict = {}
+
+    out["mac_address"] = record["mac_address"]
+    out["ip_address"] = record["ip_address"]
+
+    if record.get("hostname") is not None:
+        out["hostname"] = record["hostname"]
+
+    if record.get("vendor") is not None:
+        slug = record["vendor"]
+        out["manufacturer"] = _VENDOR_DISPLAY.get(slug, slug)
+
+    if record.get("product") is not None:
+        slug = record["product"]
+        out["model"] = _PRODUCT_DISPLAY.get(slug, slug)
+
+    if record.get("version") is not None:
+        out["app_sw_version"] = record["version"]
+
+    if record.get("device_class") is not None:
+        out["category"] = record["device_class"]
+
+    out["open_ports_tcp"] = record["open_ports"]
+
+    if record.get("confidence") is not None:
+        out["external_keys"] = {"tapirxl_confidence": record["confidence"]}
+
+    return out
+
+
+def _load_golden() -> list[dict]:
+    return [
+        json.loads(line)
+        for line in _GOLDEN_JSONL.read_text().splitlines()
+        if line.strip()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: _vrl_transform unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_vrl_transform_maps_device_class_to_category() -> None:
+    """device_class → category per the VRL contract."""
+    record = {
+        "mac_address": "00:09:FB:BD:75:6D",
+        "ip_address": "10.10.10.21",
+        "hostname": "MX700-bed12",
+        "vendor": "philips",
+        "product": "intellivue_mx700",
+        "version": None,
+        "device_class": "patient_monitor",
+        "open_ports": [3702],
+        "confidence": "LOW",
+    }
+    out = _vrl_transform(record)
+    assert out["category"] == "patient_monitor"
+    assert out["manufacturer"] == "Philips"
+    assert out["model"] == "IntelliVue MX700"
+    assert out["open_ports_tcp"] == [3702]
+    assert "app_sw_version" not in out
+
+
+def test_vrl_transform_omits_category_when_device_class_null() -> None:
+    """Null device_class → category absent from output (existing value preserved on upsert)."""
+    record = {
+        "mac_address": "00:90:20:AA:BB:01",
+        "ip_address": "10.10.10.30",
+        "hostname": "BRILL-CT01",
+        "vendor": "philips",
+        "product": "brilliance_ict",
+        "version": None,
+        "device_class": None,
+        "open_ports": [],
+        "confidence": "HIGH",
+    }
+    out = _vrl_transform(record)
+    assert "category" not in out
+
+
+@pytest.mark.parametrize(
+    "record",
+    [r for r in _load_golden() if r.get("device_class") is not None],
+    ids=lambda r: r["ip_address"],
+)
+def test_vrl_transform_golden_categorised_records(record: dict) -> None:
+    """Every categorised golden record produces category == device_class."""
+    out = _vrl_transform(record)
+    assert out["category"] == record["device_class"]
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: single-record persistence
+# ---------------------------------------------------------------------------
+
+
+def test_device_class_persisted_through_upsert(asset_edit_client) -> None:
+    """category from VRL transform survives PUT /api/assets/upsert/ → Asset.category."""
+    from blueflow import models
+
+    payload = _vrl_transform(
+        {
+            "mac_address": "00:09:FB:BD:75:6D",
+            "ip_address": "10.10.10.21",
+            "hostname": "MX700-bed12",
+            "vendor": "philips",
+            "product": "intellivue_mx700",
+            "version": None,
+            "device_class": "patient_monitor",
+            "open_ports": [3702],
+            "confidence": "LOW",
+        }
+    )
+
+    resp = asset_edit_client.put(
+        "/api/assets/upsert/",
+        json.dumps(payload),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    asset = models.Asset.objects.get(mac_address="00:09:fb:bd:75:6d")
+    assert asset.category == "patient_monitor"
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: full pipeline regression
+# ---------------------------------------------------------------------------
+
+
+def test_golden_device_class_propagates_to_viper_role(
+    asset_edit_client, celery_app
+) -> None:
+    """All 8 golden TapirXL records: device_class reaches Viper as role.
+
+    Pipeline under test:
+      tapirxl_telemetry.jsonl
+        → _vrl_transform   (mirrors upload-vector.vrl)
+        → PUT /api/assets/upsert/
+        → Asset.category
+        → ViperWebhookResponseList
+        → ViperAsset.role
+    """
+    records = _load_golden()
+
+    # Phase 1 — upsert all golden records into BlueFlow
+    for record in records:
+        payload = _vrl_transform(record)
+        resp = asset_edit_client.put(
+            "/api/assets/upsert/",
+            json.dumps(payload),
+            content_type="application/json",
+        )
+        assert resp.status_code in (200, 201), (
+            f"Upsert failed for {record['ip_address']}: {resp.data}"
+        )
+
+    # Phase 2 — run the Viper webhook, capturing every outbound POST
+    with patch("blueflow.celery.tasks.requests.post") as mock_post:
+        from blueflow.celery.tasks import viper_webhook
+
+        viper_webhook.apply(
+            args=[
+                ViperWebhookRequest(
+                    callback="https://viper.example.com/integration/",
+                    since="1800-01-01T00:00:00Z",
+                    before=None,
+                    max_pages=100,
+                    page_size=100,
+                ).to_dict(),
+                    str(uuid.uuid4()),
+            ]
+        )
+
+    # Flatten all pages into a single IP → role map
+    all_items = [
+        item
+        for call in mock_post.call_args_list
+        for item in call.kwargs["json"]["items"]
+    ]
+    role_by_ip: dict[str, str] = {item["ip"]: item["role"] for item in all_items}
+
+    # Phase 3 — assert role == device_class for every golden record
+    for record in records:
+        ip = record["ip_address"]
+        expected = record["device_class"] or ""
+        assert ip in role_by_ip, f"{ip} missing from Viper output"
+        assert role_by_ip[ip] == expected, (
+            f"{ip}: expected role={expected!r}, got role={role_by_ip[ip]!r}"
+        )

--- a/blueflow/tests/test_viper_models.py
+++ b/blueflow/tests/test_viper_models.py
@@ -35,10 +35,10 @@ def _make_asset(**overrides) -> models.Asset:
 
 
 def test_viper_asset_to_dict_includes_required_keys():
-    """Viper's OpenAPI marks ip, upstream_api, vendor_id as required."""
+    """Viper's OpenAPI marks ip, upstreamApi, vendorId as required."""
     asset = _make_asset()
     payload = ViperAsset(asset).to_dict()
-    for key in ("ip", "upstream_api", "vendor_id"):
+    for key in ("ip", "upstreamApi", "vendorId"):
         assert key in payload, f"required key {key!r} missing from payload"
 
 
@@ -63,19 +63,34 @@ def test_viper_asset_role_is_populated_from_category():
     assert payload["role"] == "infusion-pump"
 
 
-def test_viper_asset_role_is_empty_string_when_category_unset():
-    """Role falls back to empty string (not pruned) when no category."""
+def test_viper_asset_role_omitted_when_category_unset():
+    """Role is omitted when no category (Viper rejects empty strings)."""
     asset = _make_asset(category=None)
     payload = ViperAsset(asset).to_dict()
-    assert payload["role"] == ""
+    assert "role" not in payload
+
+
+def test_viper_asset_vendor_id_maps_manufacturer():
+    """vendorId is Asset.manufacturer (TapirXL vendor), not nic_vendor or PK."""
+    asset = _make_asset(manufacturer="Philips", nic_vendor="Some OUI Org")
+    payload = ViperAsset(asset).to_dict()
+    assert payload["vendorId"] == "Philips"
+    assert payload["vendorId"] != "Some OUI Org"
+
+
+def test_viper_asset_vendor_id_empty_when_manufacturer_unset():
+    """vendorId is present but empty when manufacturer is null."""
+    asset = _make_asset(manufacturer=None, nic_vendor="Some OUI Org")
+    payload = ViperAsset(asset).to_dict()
+    assert payload["vendorId"] == ""
 
 
 def test_viper_asset_upstream_api_uses_base_url_and_asset_id():
-    """upstream_api points back at the asset's BlueFlow detail URL."""
+    """upstreamApi points back at the asset's BlueFlow detail URL."""
     asset = _make_asset()
     payload = ViperAsset(asset).to_dict()
     expected = f"{settings.BASE_URL}/api/assets/{asset.id}/"
-    assert payload["upstream_api"] == expected
+    assert payload["upstreamApi"] == expected
 
 
 def test_viper_asset_ip_comes_from_asset_ip_address():
@@ -92,21 +107,24 @@ def test_viper_asset_ip_is_empty_string_when_no_address():
     assert payload["ip"] == ""
 
 
-def test_viper_asset_location_has_four_string_keys():
-    """Location is the {facility, building, floor, room} object, not {}."""
+def test_viper_asset_location_omitted_when_all_empty():
+    """Blank location quadrants are omitted from the wire payload."""
     asset = _make_asset()
     payload = ViperAsset(asset).to_dict()
-    location = payload["location"]
-    assert set(location.keys()) == {"facility", "building", "floor", "room"}
-    for value in location.values():
-        assert value == ""
+    assert "location" not in payload
 
 
-def test_viper_asset_cpe_is_present_even_when_empty():
-    """Cpe stays in the payload as '' (not nullable per Viper docs)."""
+def test_viper_asset_cpe_omitted_when_empty():
+    """Invalid/empty cpe is omitted; Viper assigns UNKNOWN_CPE on ingest."""
     asset = _make_asset()
     payload = ViperAsset(asset).to_dict()
-    assert payload["cpe"] == ""
+    assert "cpe" not in payload
+
+
+def test_viper_asset_mac_address_is_camel_case():
+    asset = _make_asset(mac_address="00:11:22:33:44:55")
+    payload = ViperAsset(asset).to_dict()
+    assert payload["macAddress"] == "00:11:22:33:44:55"
 
 
 def test_viper_asset_utilization_is_length_seven_list():
@@ -177,12 +195,13 @@ def _make_response(**overrides) -> ViperWebhookResponse:
 
 
 def test_response_uses_total_count_key_not_total():
-    """Wrapper renames: total → total_count."""
+    """Wrapper emits totalCount (camelCase) for Viper integrationUpload."""
     response = _make_response(total_count=SAMPLE_TOTAL_COUNT)
     payload = response.to_dict()
-    assert "total_count" in payload
-    assert payload["total_count"] == SAMPLE_TOTAL_COUNT
+    assert "totalCount" in payload
+    assert payload["totalCount"] == SAMPLE_TOTAL_COUNT
     assert "total" not in payload
+    assert "total_count" not in payload
 
 
 def test_response_uses_next_and_previous_keys_not_page_suffixed():

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -103,12 +103,25 @@ class AssetUpsertSerializer(serializers.Serializer):
         required=False, allow_blank=True, allow_null=True
     )
     os = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    app_sw_version = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
     category = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    device_class = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
     external_keys = serializers.JSONField(required=False, allow_null=True)
     open_ports_tcp = serializers.ListField(
         child=serializers.IntegerField(min_value=1, max_value=TCP_PORT_MAX),
         required=False,
     )
+
+    def validate(self, attrs: dict) -> dict:
+        """Map TapirXL ``device_class`` to ``category`` when Vector is bypassed."""
+        device_class = attrs.pop("device_class", None)
+        if device_class and not attrs.get("category"):
+            attrs["category"] = device_class
+        return attrs
 
     def validate_open_ports_tcp(self, ports_list: list[int]) -> list[int]:
         """Deduplicate and sort ports."""


### PR DESCRIPTION
- **test(viper): add regression for TapirXL device_class -> Viper role pipeline**
- **fix(upsert): accept TapirXL device_class and app_sw_version on asset upsert**
- **fix(viper): emit camelCase integrationUpload payload**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Asset upsert API now accepts `app_sw_version` and `device_class` fields.
  * Device class automatically normalized to category when provided.
  * Viper webhook responses updated to use camelCase JSON format.

* **Tests**
  * Added regression test coverage for telemetry integration with Viper pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/virtalabs/blueflow/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->