### PR TITLE
Swap model for product in asset views

### DIFF
--- a/blueflow/models/viper.py
+++ b/blueflow/models/viper.py
@@ -83,6 +83,10 @@ def _project_usage(asset: Asset) -> list[dict[str, int]]:
     return days
 
 
+Utilization = list[dict[str, int]]
+Location = dict[str, str]
+
+
 @dataclass
 class ViperAsset:
     """Data for a viper asset."""
@@ -95,10 +99,10 @@ class ViperAsset:
     hostname: str
     mac_address: str
     serial_number: str
-    location: dict[str, str]
+    location: Location
     status: str
     vendor_id: str
-    utilization: list[dict[str, int]]
+    utilization: Utilization
 
     def __init__(self, asset: Asset):
         self.ip = str(asset.ip_address) if asset.ip_address else ""
@@ -118,7 +122,7 @@ class ViperAsset:
         self.vendor_id = str(asset.manufacturer or "")
         self.utilization = _project_usage(asset)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, str | Utilization | Location]:
         """Return a JSON-serializable dict for Viper integrationUpload.
 
         Uses camelCase keys per Viper's ``assetInputSchema``.  ``role`` is

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -430,7 +430,7 @@ class AssetFilter(django_filters.rest_framework.FilterSet):
                 "exact",
                 "isnull",
             ],
-            "model": [
+            "product": [
                 "istartswith",
                 "icontains",
                 "iregex",
@@ -536,7 +536,7 @@ class AssetViewSet(
         "ip_address",
         "mac_address",
         "manufacturer",
-        "model",
+        "product",
         "name",
         "nic_vendor",
         "os",
@@ -566,7 +566,7 @@ class AssetViewSet(
             "mac_address",
             "nic_vendor",
             "manufacturer",
-            "model",
+            "product",
             "os",
             "app_sw_version",
             "serial_number",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Updates**
  * Asset filtering, searching, and CSV exports now use "product" field instead of "model"

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/virtalabs/blueflow/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->