### PR TITLE
Add in vendor ID and logger

### DIFF
--- a/blueflow/celery/tasks.py
+++ b/blueflow/celery/tasks.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 import requests
 from celery import Task as BaseTask
@@ -37,36 +38,39 @@ def _send_viper_payload(viper_data: ViperWebhookRequest, request_id: str) -> str
     viper_responses = []
     for response in response_list:
         as_dict = response.to_dict()
-        response = requests.post(
+        v_res = requests.post(
             viper_data.callback,
             json=as_dict,
             headers={"Content-Type": "application/json"},
         )
-        if response.status_code >= 400:
-            return json.dumps(response.json(), indent=4)
-        response.raise_for_status()
-        viper_responses.append(response.json())
+        if v_res.status_code >= 400:
+            return json.dumps(v_res.json(), indent=4)
+        v_res.raise_for_status()
+        viper_responses.append(v_res.json())
     return json.dumps(viper_responses, indent=4)
 
 
 @celery_app.task(base=Task)
-def viper_webhook(data: dict, request_id: str = ""):
+def viper_webhook(data: dict[str, Any], request_id: str = "") -> str:
     """Process a viper webhook."""
     viper_data = ViperWebhookRequest(**data)
     logger.info("Processing viper webhook: %s", viper_data)
     if request_id:
-        ViperWebhookJob.objects.filter(pk=request_id).update(
+        _ = ViperWebhookJob.objects.filter(pk=request_id).update(
             status=ViperWebhookJob.Status.STARTED
         )
     try:
-        _send_viper_payload(viper_data, request_id)
-    except Exception:
+        res = _send_viper_payload(viper_data, request_id)
+        logger.info("Job completed with respons: %", res)
         if request_id:
-            ViperWebhookJob.objects.filter(pk=request_id).update(
+            _ = ViperWebhookJob.objects.filter(pk=request_id).update(
+                status=ViperWebhookJob.Status.FINISHED
+            )
+        return res
+    except Exception as e:
+        if request_id:
+            _ = ViperWebhookJob.objects.filter(pk=request_id).update(
                 status=ViperWebhookJob.Status.ERROR
             )
-        raise
-    if request_id:
-        ViperWebhookJob.objects.filter(pk=request_id).update(
-            status=ViperWebhookJob.Status.FINISHED
-        )
+        logger.warning("Job failed with err: %", str(e))
+        return str(e)

--- a/blueflow/models/viper.py
+++ b/blueflow/models/viper.py
@@ -116,7 +116,9 @@ class ViperAsset:
         self.serial_number = asset.serial_number or ""
         self.location = {"facility": "", "building": "", "floor": "", "room": ""}
         self.status = "Active"
-        self.vendor_id = str(asset.id or "NO_ID_FOUND")
+        if not asset.id:
+            raise ValueError("How did we get an asset with no id?")
+        self.vendor_id = str(asset.id)
         self.utilization = _project_usage(asset)
         self.product = str(asset.product) if asset.product else ""
 

--- a/blueflow/models/viper.py
+++ b/blueflow/models/viper.py
@@ -116,7 +116,7 @@ class ViperAsset:
         self.serial_number = asset.serial_number or ""
         self.location = {"facility": "", "building": "", "floor": "", "room": ""}
         self.status = "Active"
-        self.vendor_id = str(asset.manufacturer or "")
+        self.vendor_id = str(asset.id or "NO_ID_FOUND")
         self.utilization = _project_usage(asset)
         self.product = str(asset.product) if asset.product else ""
 


### PR DESCRIPTION
Vendor ID now points to Asset.id as was originally inteded by the Viper team. Additionally added proper worker return values and now log on both a valid response and an error