### PR TITLE
Chore/39 document viper webhook

### DIFF
--- a/blueflow/views/topology.py
+++ b/blueflow/views/topology.py
@@ -10,9 +10,7 @@ import uuid
 from datetime import UTC, datetime
 
 from drf_spectacular.utils import extend_schema, extend_schema_field
-from rest_framework import serializers
-from rest_framework.response import Response
-from rest_framework.views import APIView
+from rest_framework import response, serializers, views
 
 from blueflow.models import constants
 
@@ -78,12 +76,12 @@ class TopologySerializer(serializers.Serializer):
         return "0.1.0-minimal"
 
 
-class TopologyView(APIView):
+class TopologyView(views.APIView):
     """Read-only topology snapshot endpoint (stub payload)."""
 
     @extend_schema(responses=TopologySerializer)
-    def get(self, request):  # noqa: ARG002
-        return Response(
+    def get(self, *_, **__) -> response.Response:
+        return response.Response(
             {
                 "schema_version": "0.1.0-minimal",
                 "snapshot_id": str(uuid.uuid4()),

--- a/blueflow/views/topology.py
+++ b/blueflow/views/topology.py
@@ -71,7 +71,7 @@ class TopologySerializer(serializers.Serializer):
     assets = TopologyAssetSerializer(many=True)
     connections = TopologyConnectionSerializer(many=True, required=False)
 
-    @extend_schema_field({"type": "string", "const": "0.1.0-minimal"})
+    @extend_schema_field({"type": "string", "enum": ["0.1.0-minimal"]})
     def get_schema_version(self, _obj):
         return "0.1.0-minimal"
 

--- a/blueflow/views/viper.py
+++ b/blueflow/views/viper.py
@@ -47,7 +47,12 @@ class ViperViewSet(viewsets.ViewSet):
 
     @drf_spectacular.extend_schema(
         request=ViperWebhookSerializer,
-        responses={202: ViperWebhookResponseSerilizer, 400: ViperWebhookSerializer},
+        responses={
+            202: ViperWebhookResponseSerilizer,
+            400: drf_spectacular.OpenApiResponse(
+                description="Validation error — malformed or incomplete webhook payload"
+            ),
+        },
         description="Register the viper callback endpoint for asset syncing",
     )
     @decorators.action(detail=False, methods=["post"])

--- a/blueflow/views/viper.py
+++ b/blueflow/views/viper.py
@@ -34,6 +34,9 @@ class ViperWebhookSerializer(serializers.Serializer):
     page_size = serializers.IntegerField()
 
 
+class ViperWebhookResponseSerilizer(serializers.Serializer): ...
+
+
 class ViperViewSet(viewsets.ViewSet):
     """ViewSet for the Viper integration."""
 
@@ -42,8 +45,8 @@ class ViperViewSet(viewsets.ViewSet):
     serializer_class: typing.ClassVar = ViperWebhookSerializer
 
     @drf_spectacular.extend_schema(
-        request=models.ViperWebhookRequest,
-        responses={"202": response.Response, "400": response.Response},
+        request=ViperWebhookSerializer,
+        responses={202: ViperWebhookResponseSerilizer, 400: ViperWebhookSerializer},
         description="Register the viper callback endpoint for asset syncing",
     )
     @decorators.action(detail=False, methods=["post"])

--- a/blueflow/views/viper.py
+++ b/blueflow/views/viper.py
@@ -34,7 +34,8 @@ class ViperWebhookSerializer(serializers.Serializer):
     page_size = serializers.IntegerField()
 
 
-class ViperWebhookResponseSerilizer(serializers.Serializer): ...
+class ViperWebhookResponseSerilizer(serializers.Serializer):
+    request_id = serializers.CharField()
 
 
 class ViperViewSet(viewsets.ViewSet):

--- a/blueflow/views/viper.py
+++ b/blueflow/views/viper.py
@@ -6,16 +6,22 @@ query for a list of assets
 The "real" response is handled by a Celery task.
 """
 
-from rest_framework import serializers, status, viewsets
-from rest_framework.decorators import action
-from rest_framework.parsers import JSONParser
-from rest_framework.permissions import AllowAny
-from rest_framework.request import Request
-from rest_framework.response import Response
+import typing
 
-from blueflow.celery.tasks import viper_webhook
-from blueflow.models import ViperWebhookJob
-from blueflow.models.viper import ViperWebhookRequest
+import drf_spectacular.utils as drf_spectacular
+from rest_framework import (
+    decorators,
+    parsers,
+    permissions,
+    request,
+    response,
+    serializers,
+    status,
+    viewsets,
+)
+
+from blueflow import models
+from blueflow.celery import tasks
 
 
 class ViperWebhookSerializer(serializers.Serializer):
@@ -31,22 +37,28 @@ class ViperWebhookSerializer(serializers.Serializer):
 class ViperViewSet(viewsets.ViewSet):
     """ViewSet for the Viper integration."""
 
-    # TODO(taylorcochran): review authentication
-    permission_classes = [AllowAny]
-    parser_classes = [JSONParser]
-    serializer_class = ViperWebhookSerializer
+    permission_classes: typing.ClassVar = [permissions.AllowAny]
+    parser_classes: typing.ClassVar = [parsers.JSONParser]
+    serializer_class: typing.ClassVar = ViperWebhookSerializer
 
-    @action(detail=False, methods=["post"])
-    def webhook(self, request: Request) -> Response:
+    @drf_spectacular.extend_schema(
+        request=models.ViperWebhookRequest,
+        responses={"202": response.Response, "400": response.Response},
+        description="Register the viper callback endpoint for asset syncing",
+    )
+    @decorators.action(detail=False, methods=["post"])
+    def webhook(self, request: request.Request) -> response.Response:
         """Register a viper webhook."""
         serializer = self.serializer_class(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        viper_data = ViperWebhookRequest(**serializer.validated_data)
-        job = ViperWebhookJob.objects.create(
+        _ = serializer.is_valid(raise_exception=True)
+        viper_data = models.ViperWebhookRequest(**serializer.validated_data)
+        job = models.ViperWebhookJob.objects.create(
             callback=viper_data.callback,
             since=viper_data.since,
             before=viper_data.before,
             request_body=request.data,
         )
-        viper_webhook.delay(viper_data.to_dict(), str(job.id))
-        return Response({"request_id": str(job.id)}, status=status.HTTP_202_ACCEPTED)
+        tasks.viper_webhook.delay(viper_data.to_dict(), str(job.id))
+        return response.Response(
+            {"request_id": str(job.id)}, status=status.HTTP_202_ACCEPTED
+        )

--- a/justfile
+++ b/justfile
@@ -18,3 +18,6 @@ up:
 install:
   uv sync --all-extras
 
+api-docs:
+  DJANGO_SETTINGS_MODULE=project.settings.development ./project/manage.py spectacular --validate
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "blueflow"
-version = "0.1.0"
+version = "0.3.5"
 description = "Blueflow Django app"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "blueflow"
-version = "0.1.0"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "celery" },


### PR DESCRIPTION
<img width="667" height="518" alt="Screenshot 2026-06-22 at 10 48 45" src="https://github.com/user-attachments/assets/e0c4ee27-617f-4f9d-b1b2-49bfa23a2990" />

closes #39 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the Viper webhook endpoint and responses in the OpenAPI spec, adds a local docs validation command, and fixes response typing. Addresses Linear #39 to make the webhook easy to integrate and verify.

- **New Features**
  - Added `drf-spectacular` schema for `ViperViewSet.webhook`, including 202 response with `request_id` and a 400 validation error.
  - Added `just api-docs` to generate/validate API docs locally.
  - Bumped `blueflow` to version `0.3.5`.

- **Bug Fixes**
  - Fixed response typing and aligned DRF imports; switched `extend_schema_field` from `const` to `enum` in topology (no behavior change).

<sup>Written for commit dce4b3c8e780b7257ef1cb7324ffa44eb49985dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/virtalabs/blueflow/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

