### PR TITLE
chore: migrate low-impact serializers to ModelSerializer (#84)

### DIFF
--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -213,13 +213,10 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
         return days
 
 
-class HistoricalAssetSerializer(serializers.HyperlinkedModelSerializer):
+class HistoricalAssetSerializer(serializers.ModelSerializer):
     """Serializes asset history."""
 
-    history_user = serializers.HyperlinkedRelatedField(
-        view_name="blueflow:user-detail",
-        read_only=True,
-    )
+    history_user = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         """Wire this serializer to a model."""

--- a/blueflow/views/assetgroup.py
+++ b/blueflow/views/assetgroup.py
@@ -14,14 +14,11 @@ from .group import GroupSerializer
 from .utils import HugeLimitOffsetPagination
 
 
-class AssetGroupSerializer(serializers.HyperlinkedModelSerializer):
+class AssetGroupSerializer(serializers.ModelSerializer):
     """Serializes AssetGroup objects."""
 
     # Few public methods; that's just how serializers work
 
-    url = serializers.HyperlinkedIdentityField(
-        view_name="blueflow:assetgroup-detail"
-    )
     group = GroupSerializer(read_only=True)
     asset_id = IntegerField()
     group_id = IntegerField()
@@ -36,7 +33,6 @@ class AssetGroupSerializer(serializers.HyperlinkedModelSerializer):
             "provenance",
             # Fields that are created (not stored directly in schema)
             "group",
-            "url",
         )
 
 

--- a/blueflow/views/assettag.py
+++ b/blueflow/views/assettag.py
@@ -11,10 +11,9 @@ from .tag import TagSerializer
 from .utils import ChangeReasonMixin, HugeLimitOffsetPagination
 
 
-class AssetTagSerializer(serializers.HyperlinkedModelSerializer):
+class AssetTagSerializer(serializers.ModelSerializer):
     """Serializes AssetTag objects."""
 
-    url = serializers.HyperlinkedIdentityField(view_name="blueflow:assettag-detail")
     tag = TagSerializer(read_only=True)
     asset_id = IntegerField()
     tag_id = IntegerField()
@@ -29,7 +28,6 @@ class AssetTagSerializer(serializers.HyperlinkedModelSerializer):
             "provenance",
             # Fields that are created (not stored directly in schema)
             "tag",
-            "url",
         )
 
 

--- a/blueflow/views/network.py
+++ b/blueflow/views/network.py
@@ -125,18 +125,17 @@ class NetworkViewSet(WaffleSwitchMixin, viewsets.ModelViewSet):
         return Response(data)
 
 
-class CidrSerializer(serializers.HyperlinkedModelSerializer):
+class CidrSerializer(serializers.ModelSerializer):
     """Serializes cidrs.
 
     Teaches the rest_framework (the ViewSet) which fields to expect.
     """
 
-    url = serializers.HyperlinkedIdentityField(view_name="blueflow:cidr-detail")
     network_id = IntegerField()
 
     class Meta:
         model = Cidr
-        fields = ("id", "url", "cidr", "network_id")
+        fields = ("id", "cidr", "network_id")
 
 
 @extend_schema(exclude=True)
@@ -148,20 +147,15 @@ class CidrViewSet(mixins.DestroyModelMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = CidrSerializer
 
 
-class SavedSearchSerializer(serializers.HyperlinkedModelSerializer):
+class SavedSearchSerializer(serializers.ModelSerializer):
     """Serializes saved searchs.
 
     Teaches the rest_framework (the ViewSet) which fields to expect.
     """
 
-    url = serializers.HyperlinkedIdentityField(
-        view_name="blueflow:savedsearch-detail"
-    )
-
     class Meta:
         model = SavedSearch
         fields = (
-            "url",
             "id",
             "name",
             "search_query",

--- a/blueflow/views/periodic_task.py
+++ b/blueflow/views/periodic_task.py
@@ -11,15 +11,11 @@ from waffle.mixins import WaffleSwitchMixin
 logger = logging.getLogger(__name__)
 
 
-class CrontabScheduleSerializer(serializers.HyperlinkedModelSerializer):
+class CrontabScheduleSerializer(serializers.ModelSerializer):
     """Serializer.
 
     Teaches the rest_framework (the ViewSet) which fields to expect.
     """
-
-    url = serializers.HyperlinkedIdentityField(
-        view_name="blueflow:crontabschedule-detail"
-    )
 
     # Human-readable name
     display_name = serializers.SerializerMethodField("do_display_name")
@@ -38,7 +34,6 @@ class CrontabScheduleSerializer(serializers.HyperlinkedModelSerializer):
             "day_of_week",
             "day_of_month",
             "month_of_year",
-            "url",
             "display_name",
         )
 
@@ -53,15 +48,11 @@ class CrontabScheduleViewSet(WaffleSwitchMixin, viewsets.ModelViewSet):
     serializer_class = CrontabScheduleSerializer
 
 
-class IntervalScheduleSerializer(serializers.HyperlinkedModelSerializer):
+class IntervalScheduleSerializer(serializers.ModelSerializer):
     """Serializer.
 
     Teaches the rest_framework (the ViewSet) which fields to expect.
     """
-
-    url = serializers.HyperlinkedIdentityField(
-        view_name="blueflow:intervalschedule-detail"
-    )
 
     # Human-readable name
     display_name = serializers.SerializerMethodField("do_display_name")
@@ -77,7 +68,6 @@ class IntervalScheduleSerializer(serializers.HyperlinkedModelSerializer):
             "id",
             "every",
             "period",
-            "url",
             "display_name",
         )
 

--- a/blueflow/views/user.py
+++ b/blueflow/views/user.py
@@ -10,12 +10,10 @@ from waffle.mixins import WaffleSwitchMixin
 logger = logging.getLogger(__name__)
 
 
-class UserSerializer(serializers.HyperlinkedModelSerializer):
+class UserSerializer(serializers.ModelSerializer):
     """Serialize users."""
 
     # Few public methods; that's just how serializers work
-
-    url = serializers.HyperlinkedIdentityField(view_name="blueflow:user-detail")
 
     class Meta:
         """Wire serializer to the User model."""
@@ -23,7 +21,6 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
         model = User
         fields = (
             "id",
-            "url",
             "email",
             "first_name",
             "last_name",


### PR DESCRIPTION
## Summary

First slice of #84 — migrate the eight **low-risk** serializers from `HyperlinkedModelSerializer` to `ModelSerializer`. Each drops its `url` `HyperlinkedIdentityField`; `HistoricalAssetSerializer.history_user` becomes a `PrimaryKeyRelatedField`.

These were selected because they have **no action-route URL fields** (`tags_url`/`scans_url`/`add_assets_url`) and **no writable hyperlinked relations**, so the conversion is mechanical:

| Serializer | File |
|---|---|
| `UserSerializer` | `user.py` |
| `CidrSerializer` | `network.py` |
| `SavedSearchSerializer` | `network.py` |
| `CrontabScheduleSerializer` | `periodic_task.py` |
| `IntervalScheduleSerializer` | `periodic_task.py` |
| `HistoricalAssetSerializer` | `asset.py` |
| `AssetGroupSerializer` | `assetgroup.py` |
| `AssetTagSerializer` | `assettag.py` |

## Out of scope (follow-up)

Higher-risk serializers are intentionally left for later PRs: `AssetSerializer`, `ChangeLogAssetSerializer` (metaclass), `PeriodicTaskSerializer` (writable `interval`/`crontab`), `NetworkSerializer`, `GroupSerializer`, `TagSerializer`, `ScanSerializer`. The action-route URL fields need a drop-vs-`SerializerMethodField` decision first.

Note: the nested `group`/`tag` sub-serializers on `AssetGroup`/`AssetTag` remain hyperlinked until their parents (`Group`/`Tag`) are migrated — harmless, since the ViewSet still injects `request` into context.

## Breaking change

`url` is removed from these endpoints' responses; consumers must use `id`. Coordinated per the post-1.0 contract-based API direction in #84.

## Verification

- **Tests:** asset / asset_relations / asset_usage / groups / network / tags suites — same failure set as clean `develop` (27 pre-existing failures, unrelated to serializers). **Zero regressions.**
- **OpenAPI schema:** `manage.py spectacular` generates without errors (covers `SavedSearch`/`Crontab`/`Interval`/`User`, which lack direct test coverage).
- **Lint:** no new `ruff` findings versus the existing baseline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates eight low‑risk serializers from HyperlinkedModelSerializer to ModelSerializer, removing `url` fields and switching `HistoricalAssetSerializer.history_user` to a primary key. Aligns with #84’s contract-based API direction.

- **Refactors**
  - Converted: User, Cidr, SavedSearch, CrontabSchedule, IntervalSchedule, HistoricalAsset, AssetGroup, AssetTag.
  - Dropped `url` HyperlinkedIdentityField from each; nested `group`/`tag` remain hyperlinked for now.

- **Migration**
  - API responses no longer include `url`; use `id` instead.

<sup>Written for commit c4ba1e4c59f291d91c919689270ea8dc596e6b72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/virtalabs/blueflow/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

