### PR TITLE
chore: unify asset write-endpoint validation errors (#147)

### DIFF
--- a/blueflow/tests/test_asset_hostname.py
+++ b/blueflow/tests/test_asset_hostname.py
@@ -21,6 +21,9 @@ from blueflow.views.asset import AssetUpsertSerializer
 
 MAC_A = "AA:BB:CC:DD:EE:FF"
 MAC_B = "11:22:33:44:55:66"
+# AssetUpsertSerializer.manufacturer is required=True; supply it on every
+# payload that should pass field validation and reach the hostname logic.
+MFR = "Acme"
 
 
 # ---------------------------------------------------------------------------
@@ -41,20 +44,22 @@ def test_upsert_serializer_accepts_null_hostname() -> None:
     The model is nullable on purpose — see test_db_allows_multiple_null_hostnames
     for why. The wire-level acceptance of `null` is part of the upsert contract.
     """
-    serializer = AssetUpsertSerializer(data={"mac_address": MAC_A, "hostname": None})
+    serializer = AssetUpsertSerializer(
+        data={"mac_address": MAC_A, "hostname": None, "manufacturer": MFR}
+    )
     assert serializer.is_valid(), serializer.errors
 
 
 def test_upsert_serializer_accepts_missing_hostname() -> None:
     """Omitting hostname entirely is also 'absent' and must pass validation."""
-    serializer = AssetUpsertSerializer(data={"mac_address": MAC_A})
+    serializer = AssetUpsertSerializer(data={"mac_address": MAC_A, "manufacturer": MFR})
     assert serializer.is_valid(), serializer.errors
 
 
 def test_upsert_serializer_accepts_real_hostname() -> None:
     """A non-empty hostname passes validation."""
     serializer = AssetUpsertSerializer(
-        data={"mac_address": MAC_A, "hostname": "foo.example"},
+        data={"mac_address": MAC_A, "hostname": "foo.example", "manufacturer": MFR},
     )
     assert serializer.is_valid(), serializer.errors
 
@@ -68,7 +73,9 @@ def test_upsert_creates_asset_with_hostname(asset_edit_client: APIClient) -> Non
     """Happy path: new asset with a fresh hostname returns 201."""
     response = asset_edit_client.put(
         "/api/assets/upsert/",
-        json.dumps({"mac_address": MAC_A, "hostname": "foo.example"}),
+        json.dumps(
+            {"mac_address": MAC_A, "hostname": "foo.example", "manufacturer": MFR}
+        ),
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_201_CREATED
@@ -82,7 +89,9 @@ def test_upsert_same_mac_same_hostname_is_legitimate_noop(
     models.Asset.objects.create(mac_address=MAC_A, hostname="foo.example")
     response = asset_edit_client.put(
         "/api/assets/upsert/",
-        json.dumps({"mac_address": MAC_A, "hostname": "foo.example"}),
+        json.dumps(
+            {"mac_address": MAC_A, "hostname": "foo.example", "manufacturer": MFR}
+        ),
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_200_OK
@@ -95,7 +104,9 @@ def test_upsert_same_mac_new_hostname_is_legitimate_update(
     asset = models.Asset.objects.create(mac_address=MAC_A, hostname="old.example")
     response = asset_edit_client.put(
         "/api/assets/upsert/",
-        json.dumps({"mac_address": MAC_A, "hostname": "new.example"}),
+        json.dumps(
+            {"mac_address": MAC_A, "hostname": "new.example", "manufacturer": MFR}
+        ),
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_200_OK
@@ -110,7 +121,9 @@ def test_upsert_different_mac_existing_hostname_is_rejected(
     existing = models.Asset.objects.create(mac_address=MAC_A, hostname="foo.example")
     response = asset_edit_client.put(
         "/api/assets/upsert/",
-        json.dumps({"mac_address": MAC_B, "hostname": "foo.example"}),
+        json.dumps(
+            {"mac_address": MAC_B, "hostname": "foo.example", "manufacturer": MFR}
+        ),
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -126,7 +139,9 @@ def test_upsert_against_null_mac_owner_is_rejected(
     existing = models.Asset.objects.create(mac_address=None, hostname="foo.example")
     response = asset_edit_client.put(
         "/api/assets/upsert/",
-        json.dumps({"mac_address": MAC_A, "hostname": "foo.example"}),
+        json.dumps(
+            {"mac_address": MAC_A, "hostname": "foo.example", "manufacturer": MFR}
+        ),
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -140,7 +155,7 @@ def test_upsert_without_hostname_does_not_check_conflicts(
     models.Asset.objects.create(mac_address=MAC_B, hostname="taken.example")
     response = asset_edit_client.put(
         "/api/assets/upsert/",
-        json.dumps({"mac_address": MAC_A}),
+        json.dumps({"mac_address": MAC_A, "manufacturer": MFR}),
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_201_CREATED

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -143,12 +143,14 @@ class BulkAssetUpdateListSerializer(serializers.ListSerializer):
 
     def validate(self, attrs: list[dict]) -> list[dict]:
         """Reject a batch containing the same id more than once."""
-        ids = [item["id"] for item in attrs]
-        duplicates = sorted({i for i in ids if ids.count(i) > 1})
-        if duplicates:
-            raise serializers.ValidationError(
-                {"detail": f"Duplicate id in request: {duplicates[0]}."}
-            )
+        ids: list[int] = [item["id"] for item in attrs]
+        seen: set[int] = set()
+        for i in ids:
+            if i in seen:
+                raise serializers.ValidationError(
+                    {"detail": f"Duplicate id in request: {i}."}
+                )
+            seen.add(i)
         return attrs
 
 

--- a/blueflow/views/asset.py
+++ b/blueflow/views/asset.py
@@ -93,10 +93,29 @@ class AssetUpsertSerializer(serializers.Serializer):
     services = AssetServiceSerializer(many=True, required=False)
 
     def validate(self, attrs: dict) -> dict:
-        """Map TapirXL ``device_class`` to ``category`` when Vector is bypassed."""
+        """Map ``device_class`` to ``category`` and reject hostname conflicts.
+
+        ``device_class`` is folded into ``category`` when Vector is bypassed
+        (TapirXL). A hostname already owned by a *different* MAC is a conflict;
+        same-MAC reuse and absent/null hostnames fall through (empty strings are
+        blocked at the field level via ``allow_blank=False``).
+        """
         device_class = attrs.pop("device_class", None)
         if device_class and not attrs.get("category"):
             attrs["category"] = device_class
+
+        hostname = attrs.get("hostname")
+        if hostname:
+            conflict = (
+                models.Asset.objects.filter(hostname=hostname)
+                .exclude(mac_address=attrs["mac_address"])
+                .first()
+            )
+            if conflict is not None:
+                msg = (
+                    f"Hostname '{hostname}' is already used by asset id={conflict.id}."
+                )
+                raise serializers.ValidationError({"hostname": [msg]})
         return attrs
 
     def validate_services(
@@ -112,6 +131,43 @@ class AssetUpsertSerializer(serializers.Serializer):
             seen.add(key)
             deduped.append(s)
         return deduped
+
+
+class BulkAssetUpdateListSerializer(serializers.ListSerializer):
+    """Validates the *batch envelope* for ``PATCH /api/assets/bulk_update/``.
+
+    Per-item field validation and the id-to-instance lookup stay in the view;
+    this enforces only the cross-item constraint that ids are unique. Runs after
+    every child item has validated, so ``item["id"]`` is guaranteed present.
+    """
+
+    def validate(self, attrs: list[dict]) -> list[dict]:
+        """Reject a batch containing the same id more than once."""
+        ids = [item["id"] for item in attrs]
+        duplicates = sorted({i for i in ids if ids.count(i) > 1})
+        if duplicates:
+            raise serializers.ValidationError(
+                {"detail": f"Duplicate id in request: {duplicates[0]}."}
+            )
+        return attrs
+
+
+class BulkAssetUpdateSerializer(serializers.Serializer):
+    """One item in a bulk-update batch: requires an ``id`` to target an asset.
+
+    Other asset fields pass through untouched here — they are validated and
+    applied per-item by :class:`AssetSerializer` in the view. This serializer
+    exists only to gate the batch envelope (list shape, id presence, id
+    uniqueness) through DRF's standard ``ValidationError`` pathway, so every
+    asset write endpoint surfaces validation failures uniformly.
+    """
+
+    id = serializers.IntegerField(required=True)
+
+    class Meta:
+        """Route ``many=True`` instances through the duplicate-id check."""
+
+        list_serializer_class = BulkAssetUpdateListSerializer
 
 
 # Usage field schema. Index follows Python's datetime.weekday() / ISO 8601:
@@ -827,29 +883,17 @@ class AssetViewSet(
                 {"id": 2, "ip_address": "10.0.0.5", "os": "Linux"}
             ]
         """
-        if not isinstance(request.data, list):
-            return Response(
-                {"detail": "Expected a list of objects."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        # Validate the batch envelope (list shape, id presence, id uniqueness)
+        # through DRF's standard ValidationError pathway.
+        envelope = BulkAssetUpdateSerializer(data=request.data, many=True)
+        envelope.is_valid(raise_exception=True)
 
-        # Phase 1: normalise and validate every item before touching the DB.
-        validated: list[tuple[models.Asset, AssetSerializer]] = []
-        seen_ids: set[int] = set()
+        # Phase 1: resolve + validate every item before touching the DB. The
+        # id-to-instance lookup is a 404 (a missing resource, not a client-side
+        # validation failure), so it stays here rather than in the serializer.
+        validated: list[AssetSerializer] = []
         for item in request.data:
-            asset_id = item.get("id")
-            if asset_id is None:
-                return Response(
-                    {"detail": "Each item must include an 'id' field."},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-            if asset_id in seen_ids:
-                return Response(
-                    {"detail": f"Duplicate id in request: {asset_id}."},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-            seen_ids.add(asset_id)
-
+            asset_id = item["id"]
             try:
                 asset = models.Asset.objects.get(pk=asset_id)
             except models.Asset.DoesNotExist:
@@ -861,11 +905,11 @@ class AssetViewSet(
                 asset, data=item, partial=True, context={"request": request}
             )
             serializer.is_valid(raise_exception=True)
-            validated.append((asset, serializer))
+            validated.append(serializer)
 
         # Phase 2: commit all updates atomically — all succeed or none do.
         with transaction.atomic():
-            results = [serializer.save() for _asset, serializer in validated]
+            results = [serializer.save() for serializer in validated]
 
         return Response(
             AssetSerializer(results, many=True, context={"request": request}).data,
@@ -885,32 +929,13 @@ class AssetViewSet(
         For batch partial-updates of assets with known IDs, use
         ``PATCH /api/assets/bulk_update/`` instead.
         """
+        # Field validation plus the hostname-conflict guard both live in
+        # AssetUpsertSerializer.validate(); raise_exception=True routes any
+        # failure through DRF's exception handler for a uniform 400 envelope.
         serializer = AssetUpsertSerializer(data=request.data)
-        if not serializer.is_valid():
-            return Response(serializer.errors, status.HTTP_400_BAD_REQUEST)
+        serializer.is_valid(raise_exception=True)
 
         validated = serializer.validated_data
-
-        # Reject if the proposed hostname is already owned by a different MAC.
-        # Same-MAC reuse (a legitimate update) falls through; missing/null
-        # hostname falls through. Empty strings are blocked by the serializer.
-        proposed_hostname = validated.get("hostname")
-        if proposed_hostname:
-            conflict = (
-                models.Asset.objects.filter(hostname=proposed_hostname)
-                .exclude(mac_address=validated["mac_address"])
-                .first()
-            )
-            if conflict is not None:
-                return Response(
-                    {
-                        "hostname": [
-                            f"Hostname '{proposed_hostname}' is already used by "
-                            f"asset id={conflict.id}.",
-                        ],
-                    },
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
 
         created = False
         mac_address = validated.pop("mac_address")


### PR DESCRIPTION
Closes #147.

## Summary

Unifies how asset write endpoints surface client-side validation failures. Previously two response shapes existed for the same logical condition: most paths `raise serializers.ValidationError(...)` (normalized by DRF's exception handler), while a few built a manual `Response(..., HTTP_400_BAD_REQUEST)` that bypassed it. This converts every remaining manual-400 validation site in `blueflow/views/asset.py` to serializer-driven validation.

## Changes

**`upsert` — fully serializer-native**
- Moved the hostname-conflict guard into `AssetUpsertSerializer.validate()`.
- Replaced `if not serializer.is_valid(): return Response(serializer.errors, 400)` with `serializer.is_valid(raise_exception=True)`.
- The conflict envelope (`{"hostname": [...]}`) is byte-for-byte preserved, so existing assertions are unchanged.

**`bulk_update` — dedicated envelope serializer**
- Added `BulkAssetUpdateSerializer(many=True)` + `BulkAssetUpdateListSerializer` to validate list shape, `id` presence, and `id` uniqueness through DRF's standard pathway.
- The `id`-to-instance lookup stays in the view as a **404** (a missing resource, not a client-side validation failure — explicitly out of scope per the issue).

**Tests**
- Supplied the now-required `manufacturer` field on the `upsert` payloads in `test_asset_hostname.py`. These were pre-existing baseline failures (they 400'd at field validation before reaching any hostname logic); adding the field restores coverage of the hostname-conflict path.

## Acceptance criteria

- [x] No remaining `return Response(..., HTTP_400_BAD_REQUEST)` validation sites in `asset.py` (the only manual `Response` left is the intentional 404).
- [x] Hostname-conflict envelope shape unchanged; no caller-visible behavior change.
- [x] Hostname suite green (15/15). The hostname-conflict path is independently verified to still return 400 with `{"hostname": ["...id=N..."]}`.

## Test results

- `blueflow/tests/test_asset_hostname.py`: 15 passed (was 6/15 on the broken baseline).
- `test_asset.py` + `test_asset_hostname.py` combined: `15 failed, 51 passed` vs. baseline `24 failed, 42 passed` — the 9 hostname tests recovered, no new failures. The remaining 15 are unrelated pre-existing breakage (`test_app_sw_*`, `test_api_create_asset_mac_*`, `test_patch_asset`, `test_set_name_null`).
- `ruff check` and `ruff format` clean.

## Out of scope

- Other viewsets (`vulnerability`, `network`, etc.) — scoped to `asset.py` per the issue.
- The TOCTOU race flagged separately on the upsert conflict check.
- Investigating *why* `AssetUpsertSerializer.manufacturer` became `required=True` — the test fixtures are aligned to the current contract; whether that tightening was intentional is a separate question.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unify validation for asset write endpoints by routing all 400s through DRF serializers. Hostname-conflict errors keep the same envelope; `upsert` and `bulk_update` now behave consistently.

- **Refactors**
  - `upsert`: moved hostname conflict into `AssetUpsertSerializer.validate()` and switched to `serializer.is_valid(raise_exception=True)`; preserves the `{"hostname": [...]}` error shape.
  - `bulk_update`: added `BulkAssetUpdateSerializer` + `BulkAssetUpdateListSerializer` to validate list shape and `id` presence; simplified duplicate `id` detection; keep id-to-instance lookup as a 404; apply updates atomically.
  - Tests: updated `test_asset_hostname.py` to include required `manufacturer` so hostname cases hit the conflict path.

<sup>Written for commit d6e6b58ab143433c8b2627b0bc67944527af077e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/virtalabs/blueflow/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

