### PR TITLE
Feature/184 docker tag

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,34 @@
+
+name: Docker Push
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  docker-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          push: true
+          # gh handily gives us the tag that triggered this workflow
+          tags: |
+            virtalabsinc/blueflow:${{ github.ref_name }}
+            virtalabsinc/blueflow:latest
+
+
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,9 +20,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      # TODO: Remove continue-on-error once baseline lint violations
-      # (~764 as of 2026-04-15) are resolved. The agent harness
-      # detects the actual failure via check-run annotations.
+      # TODO(taylorcochran): Remove continue-on-error once baseline lint violations
+      # https://github.com/virtalabs/blueflow/milestone/5
       - name: Check linting
         continue-on-error: true
         run: uv run ruff check .

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,7 +20,7 @@ jobs:
         # https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
         with:
           token: ${{ secrets.TAG_PAT }}
-          fetch-depth: 2 # allows the git diff to work
+          fetch-depth: 0 # allows the git diff to work
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,47 @@
+name: Tag
+
+on:
+  push:
+    branches: [develop, main]
+    # only run if we updated the versioning
+    paths:
+      - "pyproject.toml"
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    outputs:
+      version_tag: ${{ steps.pull_tag.outputs.version_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        # gh blocks recusrive calls by default
+        # using a PAT we can opt-in
+        # triggering any downstream tag related workflows
+        # https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
+        with:
+          token: ${{ secrets.TAG_PAT }}
+          fetch-depth: 2 # allows the git diff to work
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Ensure Version Bump
+        # gh runs with -eo and will exit on non-zero for us
+        run: |
+          git diff --unified=0 HEAD~1 HEAD -- pyproject.toml | grep -qE '^[+-]version'
+
+      - name: Pull version
+        id: pull_tag
+        # parse and read the pyproject.toml directly
+        # no text wrangling needed :)
+        run: |
+          VERSION=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
+          echo "version_tag=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.pull_tag.outputs.version_tag }}"
+          git push origin --tags
+


### PR DESCRIPTION
closes #184 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates release tagging and Docker image publishing. When `project.version` in `pyproject.toml` changes on `develop` or `main`, we tag the repo and publish a Docker image for that tag and `latest`.

- **New Features**
  - Auto-tagging: On pushes to `develop`/`main` that change `pyproject.toml`, verify the version changed (via git diff with full history), read it via Python, create the git tag, and push it using a PAT to allow downstream workflows.
  - Docker publish: On tag pushes matching `X.Y.Z`, build with Buildx and push `virtalabsinc/blueflow:X.Y.Z` and `virtalabsinc/blueflow:latest` to Docker Hub.

- **Migration**
  - Add repo secrets: `TAG_PAT`, `DOCKER_USERNAME`, `DOCKER_PASSWORD`.
  - Bump `project.version` in `pyproject.toml` to trigger a release.

<sup>Written for commit a0589c511043388299caf7d49a7ac9ca20abf088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/virtalabs/blueflow/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

