### PR TITLE
Bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "blueflow"
-version = "0.3.5"
+version = "0.3.6"
 description = "Blueflow Django app"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
0.3.6 to test new workflows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `blueflow` from 0.3.5 to 0.3.6 to trigger and validate new release workflows. No functional changes; version update only in `pyproject.toml`.

<sup>Written for commit ac56ec53280d00ed95a43c8f44a2c46af7fc93a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/virtalabs/blueflow/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

