### PR TITLE
Bump to 0.3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "blueflow"
-version = "0.3.6"
+version = "0.3.7"
 description = "Blueflow Django app"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
0.3.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare a patch release of `blueflow` by bumping the version from 0.3.6 to 0.3.7 in `pyproject.toml`. No code changes; this enables publishing the 0.3.7 release.

<sup>Written for commit 3ab5c4b2784fe5f851f70689acdd8ff612f46a36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/virtalabs/blueflow/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

