### PR TITLE
Add in migration check to test worjflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
+      - name: Ensure migrations are stable
+        run: uv run python project/manage.py makemigrations --check --dry-run --no-input
+
       - name: Run migrations
         run: uv run python project/manage.py migrate --noinput
 

--- a/blueflow/models/asset.py
+++ b/blueflow/models/asset.py
@@ -44,6 +44,7 @@ class Asset(django_extensions.TimeStampedModel):
 
     UNKNOWN_OUI_MANUFACTURER: str = ""
 
+    merp = models.CharField(max_length=126, blank=True, null=False, default="")
     name = models.CharField(
         max_length=126,
         blank=True,

--- a/blueflow/models/asset.py
+++ b/blueflow/models/asset.py
@@ -44,7 +44,6 @@ class Asset(django_extensions.TimeStampedModel):
 
     UNKNOWN_OUI_MANUFACTURER: str = ""
 
-    merp = models.CharField(max_length=126, blank=True, null=False, default="")
     name = models.CharField(
         max_length=126,
         blank=True,

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -42,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "blueflow"
-version = "0.3.5"
+version = "0.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "celery" },
@@ -124,6 +125,7 @@ requires-dist = [
     { name = "sh", specifier = ">=2.2.2" },
     { name = "whitenoise", marker = "extra == 'prod'", specifier = ">=6.0" },
 ]
+provides-extras = ["prod", "scanners", "dev"]
 
 [[package]]
 name = "celery"
@@ -225,7 +227,7 @@ name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065 }
 wheels = [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a migration stability check to the CI test workflow to catch missing migrations early. Updates dependency metadata in `uv.lock`, including bumping `blueflow` to `0.3.7`.

- **Migration**
  - CI now runs `uv run python project/manage.py makemigrations --check --dry-run --no-input` before `migrate` to fail on unstaged schema changes.

- **Dependencies**
  - Update `uv.lock`: bump `blueflow` to `0.3.7`, add `provides-extras`, set `revision = 1`, and standardize `click`’s `colorama` marker to `sys_platform == 'win32'`.

<sup>Written for commit 83df3903c758e66dccaed6b6a539e5e8a5d3ac29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/virtalabs/blueflow/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

