### PR TITLE
Seperate tagged and latest builds

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -1,10 +1,8 @@
-
-name: Docker Push
+name: Build & Push Latest
 
 on:
   push:
-    tags:
-      - "*.*.*"
+    branches: [develop, main]
 
 jobs:
   docker-push:
@@ -25,10 +23,6 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           push: true
-          # gh handily gives us the tag that triggered this workflow
           tags: |
-            virtalabsinc/blueflow:${{ github.ref_name }}
             virtalabsinc/blueflow:latest
-
-
 

--- a/.github/workflows/build-tagged.yml
+++ b/.github/workflows/build-tagged.yml
@@ -1,0 +1,31 @@
+name: Build & Push Tagged
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  docker-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          push: true
+          # gh handily gives us the tag that triggered this workflow
+          tags: |
+            virtalabsinc/blueflow:${{ github.ref_name }}
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# Minimal Django project for standalone blueflow run.
-
 FROM python:3.12-slim
 
 WORKDIR /app


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Split Docker image builds into two workflows to separate tagged releases from the `latest` branch builds. `latest` now comes from `develop` and `main`, while tagged builds push only their version tag.

- **Refactors**
  - Added `Build & Push Latest` workflow to push `virtalabsinc/blueflow:latest` on pushes to `develop` and `main`.
  - Updated `Build & Push Tagged` to push only `virtalabsinc/blueflow:${{ github.ref_name }}` (removed `latest`).
  - Cleaned up the Dockerfile (removed unused comments).

<sup>Written for commit 91a5634dc2e48963c72b35652f2124049edf6b0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/virtalabs/blueflow/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

