### PR TITLE
Feature/production setup

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -23,6 +23,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           push: true
+          target: develop
           tags: |
             virtalabsinc/blueflow:latest
 

--- a/.github/workflows/build-tagged.yml
+++ b/.github/workflows/build-tagged.yml
@@ -1,4 +1,4 @@
-name: Build & Push Tagged
+name: Build & Deploy Tagged
 
 on:
   push:
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v4
@@ -28,5 +29,10 @@ jobs:
           # gh handily gives us the tag that triggered this workflow
           tags: |
             virtalabsinc/blueflow:${{ github.ref_name }}
+
+      - name: Deploy versioned image
+        run: flyctl deploy --image virtalabsinc/blueflow:${{ github.ref_name }} --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
 

--- a/.github/workflows/build-tagged.yml
+++ b/.github/workflows/build-tagged.yml
@@ -24,6 +24,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           push: true
+          target: develop
           # gh handily gives us the tag that triggered this workflow
           tags: |
             virtalabsinc/blueflow:${{ github.ref_name }}

--- a/.github/workflows/build-tagged.yml
+++ b/.github/workflows/build-tagged.yml
@@ -24,7 +24,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           push: true
-          target: develop
+          target: prod
           # gh handily gives us the tag that triggered this workflow
           tags: |
             virtalabsinc/blueflow:${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Virtual environment
 .venv/
 
+# django stuff
+staticfiles/
+
 # Environment
 .env
 .env~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,28 @@
-FROM python:3.12-slim
+# =========================
+#     Base
+# =========================
+FROM python:3.12-slim AS base
 
 WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+RUN uv sync --no-install-project --frozen
+
 COPY blueflow/ ./blueflow/
 COPY project/ ./project/
 COPY tests/ ./tests/
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libpq5 \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip install uv \
-    && uv sync --frozen --no-dev
+# =========================
+#     Development
+# =========================
+FROM base as develop
+
+RUN uv sync --frozen --extra dev
 
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN useradd -m -u 1001 blueflow \
@@ -22,5 +33,26 @@ USER blueflow
 
 EXPOSE 8000
 ENV DJANGO_SETTINGS_MODULE=project.settings.development
+ENV PATH="/app/.venv/bin:$PATH"
 ENTRYPOINT ["/bin/bash", "/app/docker-entrypoint.sh"]
-CMD ["/app/.venv/bin/python", "project/manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["python", "project/manage.py", "runserver", "0.0.0.0:8000"]
+
+# =========================
+#     Production
+# =========================
+FROM base as prod
+
+RUN uv sync --frozen --extra prod
+
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN useradd -m -u 1001 blueflow \
+    && chown -R blueflow:blueflow /app \
+    && chmod +x /app/docker-entrypoint.sh
+
+USER blueflow
+
+EXPOSE 8000
+ENV DJANGO_SETTINGS_MODULE=project.settings.production
+ENV PATH="/app/.venv/bin:$PATH"
+ENTRYPOINT ["/bin/bash", "/app/docker-entrypoint.sh"]
+CMD ["gunicorn", "project.wsgi:application", "--bind", "0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY tests/ ./tests/
 # =========================
 #     Development
 # =========================
-FROM base as develop
+FROM base AS develop
 
 RUN uv sync --frozen --extra dev
 
@@ -40,7 +40,7 @@ CMD ["python", "project/manage.py", "runserver", "0.0.0.0:8000"]
 # =========================
 #     Production
 # =========================
-FROM base as prod
+FROM base AS prod
 
 RUN uv sync --frozen --extra prod
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,9 @@ services:
       - "5432:5432"
 
   web:
-    build: .
+    build:
+      context: .
+      target: ${BUILD_TARGET:-develop}
     command: /app/.venv/bin/python project/manage.py runserver 0.0.0.0:8000
     volumes:
       - .:/app # Mount app for dev workflow

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-# Run migrations then exec the container command (e.g. runserver).
-
 set -e
-uv sync --frozen --no-dev
-/app/.venv/bin/python project/manage.py migrate --noinput
+python project/manage.py collectstatic --noinput
+python project/manage.py migrate --noinput
 exec "$@"

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,30 @@
+app = 'blueflow'
+primary_region = 'iad'
+
+[build]
+  dockerfile = 'Dockerfile'
+
+[env]
+  BASE_URL = 'https://blueflow.fly.dev'
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ['app']
+
+  [[http_service.checks]]
+    interval = '30s'
+    timeout = '5s'
+    grace_period = '10s'
+    method = 'GET'
+    path = '/api/'
+    [http_service.checks.headers]
+    Host = "blueflow.fly.dev"
+
+[[vm]]
+  memory = '256mb'
+  cpus = 1
+  memory_mb = 256

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
-
+# avoid squashing failures in pipes
+set shell := ["zsh", "-uc", "-o", "pipefail"]
 
 makemigrations:
   DJANGO_SETTINGS_MODULE=project.settings.development ./project/manage.py makemigrations
@@ -14,6 +15,12 @@ run:
 
 up:
   docker-compose up
+
+build:
+  docker build --target develop .
+
+build-prod:
+  docker build --target prod .
 
 install:
   uv sync --all-extras

--- a/project/settings/development.py
+++ b/project/settings/development.py
@@ -2,7 +2,9 @@
 
 import os
 
-from .base import *
+import dj_database_url
+
+from .base import *  # noqa: F403
 
 DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() in ("1", "true", "yes")
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "dev-secret-key-not-for-production")
@@ -10,20 +12,17 @@ ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "localhost,127.0.0.1").sp
 
 CELERY_TASK_ALWAYS_EAGER = True
 
-# Database: prefer DATABASE_URL (e.g. dj-database-url), else DB_* env vars
 _database_url = os.environ.get("DATABASE_URL")
-if _database_url:
-    import dj_database_url
-
-    DATABASES = {
+DATABASES = (
+    {
         "default": dj_database_url.parse(
             _database_url,
             conn_max_age=600,
             conn_health_checks=True,
         ),
     }
-else:
-    DATABASES = {
+    if _database_url
+    else {
         "default": {
             "ENGINE": "django.db.backends.postgresql",
             "NAME": os.environ.get("DB_NAME", "blueflow"),
@@ -33,3 +32,4 @@ else:
             "PORT": os.environ.get("DB_PORT", "5432"),
         },
     }
+)

--- a/project/settings/production.py
+++ b/project/settings/production.py
@@ -2,9 +2,10 @@
 
 import os
 
-from django.core.exceptions import ImproperlyConfigured
+import dj_database_url
+from django.core import exceptions
 
-from .base import *
+from .base import *  # noqa: F403
 
 SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
 ALLOWED_HOSTS = [
@@ -13,10 +14,11 @@ ALLOWED_HOSTS = [
     if h.strip()
 ]
 if not ALLOWED_HOSTS:
-    raise ImproperlyConfigured("DJANGO_ALLOWED_HOSTS must be set in production.")
+    msg = "DJANGO_ALLOWED_HOSTS must be set in production."
+    raise exceptions.ImproperlyConfigured(msg)
 DEBUG = False
 
-MIDDLEWARE.insert(1, "whitenoise.middleware.WhiteNoiseMiddleware")
+MIDDLEWARE.insert(1, "whitenoise.middleware.WhiteNoiseMiddleware")  # noqa: F405
 
 STORAGES = {
     "default": {
@@ -25,4 +27,17 @@ STORAGES = {
     "staticfiles": {
         "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
     },
+}
+
+_database_url = os.environ.get("DATABASE_URL")
+if not _database_url:
+    msg = "DATABASE_URL must be set in production."
+    raise exceptions.ImproperlyConfigured(msg)
+
+DATABASES = {
+    "default": dj_database_url.parse(
+        _database_url,
+        conn_max_age=600,
+        conn_health_checks=True,
+    )
 }


### PR DESCRIPTION
<img width="1157" height="580" alt="Screenshot 2026-06-30 at 10 34 21" src="https://github.com/user-attachments/assets/404ac507-d468-4472-aba7-553546441414" />
<img width="1512" height="591" alt="Screenshot 2026-06-30 at 10 34 41" src="https://github.com/user-attachments/assets/860f16c1-9327-4011-88aa-7e47858fccf6" />
<img width="1624" height="992" alt="Screenshot 2026-06-30 at 10 41 15" src="https://github.com/user-attachments/assets/ed47956c-ff6c-41de-bf3d-1b63e5769bb5" />
<img width="1506" height="483" alt="Screenshot 2026-06-30 at 10 42 49" src="https://github.com/user-attachments/assets/65fdbbaf-c06c-4ed3-92b3-694649362aa8" />
<img width="1624" height="992" alt="Screenshot 2026-06-30 at 10 43 25" src="https://github.com/user-attachments/assets/0fcc84c0-36e0-43f6-a509-6ae198be8c20" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a production-ready Docker setup with separate dev/prod images, `gunicorn` + `whitenoise`, stricter Django production settings, and a Fly app config with health checks. CI/CD builds `develop` for `latest`, builds `prod` for tags, and deploys tagged images to Fly via `flyctl`.

- New Features
  - Docker: Multi-stage `Dockerfile` with `develop` and `prod`; prod runs `gunicorn` with `project.settings.production`; `uv` installed at build; venv on `PATH`.
  - Django (prod): Enforces `DJANGO_ALLOWED_HOSTS` and `DATABASE_URL`; static via `whitenoise`; Postgres via `dj_database_url`.
  - Static + migrations: Entrypoint runs `collectstatic` then `migrate`; `staticfiles/` added to `.gitignore`.
  - Local workflow: `docker-compose` can target stages via `BUILD_TARGET` (defaults to `develop`); `justfile` adds `build` and `build-prod` with a stricter shell.
  - CI/CD: `build-latest` uses `target: develop`; `build-tagged` uses `target: prod` and deploys the versioned image with `flyctl`.
  - Fly config: Adds `fly.toml` with `BASE_URL`, health check on `/api/`, and explicit `Host: blueflow.fly.dev` header.

- Migration
  - Set `DJANGO_SECRET_KEY`, `DJANGO_ALLOWED_HOSTS`, and `DATABASE_URL` in production.
  - Build/run the prod image: `docker build --target prod .` or `BUILD_TARGET=prod docker-compose up --build`.

<sup>Written for commit 71a1d2da9ee17a34a3e35067b04e6fbfe300015e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/virtalabs/blueflow/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

