### PR TITLE
Re-align create_assets and sample assets

### DIFF
--- a/blueflow/management/commands/create_assets.py
+++ b/blueflow/management/commands/create_assets.py
@@ -1,39 +1,43 @@
 """Load assets from a json file."""
 
 import json
-from collections.abc import Generator
-from pathlib import Path
+import pathlib
+import typing
+from collections import abc
 
 from django.apps import apps
-from django.core.management.base import BaseCommand
+from django.core.management import base
 
 
-def make_assets(data: dict) -> Generator[dict, None, None]:
-    for _id, asset in data.items():
+def _get_field(asset: dict, key: str, parent: str = "fields") -> typing.Any:
+    return asset.get(parent, {})[key]
+
+
+def make_assets(data: list[dict]) -> abc.Generator[dict, None, None]:
+    for asset in data:
         yield {
-            "id": _id,
-            "name": asset["name"],
-            "hostname": asset["hostname"],
-            "ip_address": asset["ip_address"],
-            "mac_address": asset["mac_address"],
-            "oui_manufacturer": asset["nic_vendor"],
-            "manufacturer": asset["manufacturer"],
-            "model": asset["product"],
-            "serial_number": asset["serial_number"],
-            "udi": asset["udi"],
-            "tag_number": asset["tag_number"],
-            "category": asset["category"],
-            "owner": asset["owner"],
-            "os": asset["os"],
-            "app_sw_version": asset["app_sw_version"],
-            "last_scanned": asset["last_scanned"],
-            "last_pinged": asset["last_pinged"],
-            "open_ports_tcp": asset["open_ports_tcp"],
-            "external_keys": asset["external_keys"],
+            "id": asset["pk"],
+            "name": _get_field(asset, "name"),
+            "hostname": _get_field(asset, "hostname"),
+            "ip_address": _get_field(asset, "ip_address"),
+            "mac_address": _get_field(asset, "mac_address"),
+            "oui_manufacturer": _get_field(asset, "nic_vendor"),
+            "manufacturer": _get_field(asset, "manufacturer"),
+            "model": _get_field(asset, "model"),
+            "serial_number": _get_field(asset, "serial_number"),
+            "udi": _get_field(asset, "udi"),
+            "tag_number": _get_field(asset, "tag_number"),
+            "category": _get_field(asset, "category"),
+            "owner": _get_field(asset, "owner"),
+            "os": _get_field(asset, "os"),
+            "app_sw_version": _get_field(asset, "app_sw_version"),
+            "last_scanned": _get_field(asset, "last_scanned"),
+            "last_pinged": _get_field(asset, "last_pinged"),
+            "external_keys": _get_field(asset, "external_keys"),
         }
 
 
-class Command(BaseCommand):
+class Command(base.BaseCommand):
     """Django manage.py sub command loads assets from a json file."""
 
     help = "Load assets from a json file"
@@ -46,8 +50,8 @@ class Command(BaseCommand):
     def handle(self, *_, **options) -> None:
         Asset = apps.get_model("blueflow", "Asset")
         file_path = options.get("filepath")
-        with Path(file_path).open(encoding="utf-8") as file:
-            data = json.loads(file.read())
+        with pathlib.Path(file_path).open(encoding="utf-8") as file:
+            data = json.load(file)
             assets = make_assets(data)
             Asset.objects.bulk_create([Asset(**asset) for asset in assets])
         self.stdout.write(

--- a/data/assets.json
+++ b/data/assets.json
@@ -11,8 +11,8 @@
       "manufacturer": "GE Healthcare",
       "model": "HiSpeed CT/e",
       "serial_number": "GH-2019-00001",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-06-03T09:17:54.263Z",
       "modified": "2026-01-16T07:42:54.263Z",
@@ -21,7 +21,6 @@
       "app_sw_version": "v2.7.78",
       "last_scanned": "2026-01-15T08:17:54.263Z",
       "last_pinged": "2026-01-16T07:42:54.263Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -37,8 +36,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Brivo CT315",
       "serial_number": "GH-2020-00002",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-03-28T09:17:54.263Z",
       "modified": "2026-01-16T08:16:54.263Z",
@@ -47,7 +46,6 @@
       "app_sw_version": "v11.3.52",
       "last_scanned": "2026-01-15T15:17:54.263Z",
       "last_pinged": "2026-01-16T08:16:54.263Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -63,8 +61,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Brivo 325",
       "serial_number": "GH-2023-00003",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-11-19T09:17:54.263Z",
       "modified": "2026-01-16T08:47:54.263Z",
@@ -73,7 +71,6 @@
       "app_sw_version": "v3.8.72",
       "last_scanned": "2026-01-14T01:17:54.263Z",
       "last_pinged": "2026-01-16T08:47:54.263Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -89,8 +86,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Lightspeed QXI",
       "serial_number": "GH-2020-00004",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-04-01T09:17:54.263Z",
       "modified": "2026-01-16T08:15:54.263Z",
@@ -99,7 +96,6 @@
       "app_sw_version": "v12.0.40",
       "last_scanned": "2026-01-14T05:17:54.263Z",
       "last_pinged": "2026-01-16T08:15:54.263Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -115,8 +111,8 @@
       "manufacturer": "GE Healthcare",
       "model": "BrightSpeed Excel",
       "serial_number": "GH-2022-00005",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-07-01T09:17:54.263Z",
       "modified": "2026-01-16T09:05:54.263Z",
@@ -125,7 +121,6 @@
       "app_sw_version": "v7.6.24",
       "last_scanned": "2026-01-14T00:17:54.263Z",
       "last_pinged": "2026-01-16T09:05:54.263Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -141,8 +136,8 @@
       "manufacturer": "Philips",
       "model": "Brilliance 16-slice",
       "serial_number": "P-2016-00006",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-12-30T09:17:54.263Z",
       "modified": "2026-01-16T08:24:54.263Z",
@@ -151,7 +146,6 @@
       "app_sw_version": "v2.4.28",
       "last_scanned": "2026-01-15T09:17:54.263Z",
       "last_pinged": "2026-01-16T08:24:54.263Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -163,12 +157,12 @@
       "hostname": "med-dev-00007.hospital.local",
       "ip_address": "192.168.155.190",
       "mac_address": "4d:b4:9f:47:a1:7f",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Philips",
       "model": "Brilliance Big Bore",
       "serial_number": "P-2019-00007",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-03-20T09:17:54.264Z",
       "modified": "2026-01-16T07:47:54.264Z",
@@ -177,7 +171,6 @@
       "app_sw_version": "v2.8.74",
       "last_scanned": "2026-01-14T23:17:54.264Z",
       "last_pinged": "2026-01-16T07:47:54.264Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -193,8 +186,8 @@
       "manufacturer": "Philips",
       "model": "MX16EVO2",
       "serial_number": "P-2019-00008",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-06-13T09:17:54.264Z",
       "modified": "2026-01-16T07:31:54.264Z",
@@ -203,7 +196,6 @@
       "app_sw_version": "v10.6.97",
       "last_scanned": "2026-01-14T20:17:54.264Z",
       "last_pinged": "2026-01-16T07:31:54.264Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -219,8 +211,8 @@
       "manufacturer": "Philips",
       "model": "Access CT",
       "serial_number": "P-2018-00009",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-04-08T09:17:54.264Z",
       "modified": "2026-01-16T08:08:54.264Z",
@@ -229,7 +221,6 @@
       "app_sw_version": "v9.3.30",
       "last_scanned": "2026-01-15T09:17:54.264Z",
       "last_pinged": "2026-01-16T08:08:54.264Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -245,8 +236,8 @@
       "manufacturer": "Philips",
       "model": "MX 16-slice",
       "serial_number": "P-2019-00010",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-06-29T09:17:54.264Z",
       "modified": "2026-01-16T07:38:54.264Z",
@@ -255,7 +246,6 @@
       "app_sw_version": "v15.2.54",
       "last_scanned": "2026-01-16T00:17:54.264Z",
       "last_pinged": "2026-01-16T07:38:54.264Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -271,8 +261,8 @@
       "manufacturer": "Philips",
       "model": "Ingenuity Flex",
       "serial_number": "P-2021-00011",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-05-22T09:17:54.264Z",
       "modified": "2026-01-16T08:13:54.264Z",
@@ -281,7 +271,6 @@
       "app_sw_version": "v1.2.60",
       "last_scanned": "2026-01-13T20:17:54.264Z",
       "last_pinged": "2026-01-16T08:13:54.264Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -297,8 +286,8 @@
       "manufacturer": "Philips",
       "model": "Brilliance 64-channel",
       "serial_number": "P-2018-00012",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-04-29T09:17:54.264Z",
       "modified": "2026-01-16T07:30:54.264Z",
@@ -307,7 +296,6 @@
       "app_sw_version": "v8.9.88",
       "last_scanned": "2026-01-16T02:17:54.264Z",
       "last_pinged": "2026-01-16T07:30:54.264Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -323,8 +311,8 @@
       "manufacturer": "Philips",
       "model": "Incisive CT",
       "serial_number": "P-2017-00013",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-01-31T09:17:54.264Z",
       "modified": "2026-01-16T07:21:54.264Z",
@@ -333,7 +321,6 @@
       "app_sw_version": "v7.4.56",
       "last_scanned": "2026-01-15T17:17:54.264Z",
       "last_pinged": "2026-01-16T07:21:54.264Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -349,8 +336,8 @@
       "manufacturer": "Philips",
       "model": "Ingenuity CT",
       "serial_number": "P-2017-00014",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-02-21T09:17:54.264Z",
       "modified": "2026-01-16T07:56:54.264Z",
@@ -359,7 +346,6 @@
       "app_sw_version": "v6.2.10",
       "last_scanned": "2026-01-14T10:17:54.264Z",
       "last_pinged": "2026-01-16T07:56:54.264Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -375,8 +361,8 @@
       "manufacturer": "Philips",
       "model": "Brilliance iCT",
       "serial_number": "P-2015-00015",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-04-09T09:17:54.264Z",
       "modified": "2026-01-16T07:59:54.264Z",
@@ -385,7 +371,6 @@
       "app_sw_version": "v11.1.0",
       "last_scanned": "2026-01-14T03:17:54.264Z",
       "last_pinged": "2026-01-16T07:59:54.264Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -401,8 +386,8 @@
       "manufacturer": "Philips",
       "model": "IQon Elite Spectral CT",
       "serial_number": "P-2015-00016",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-09-06T09:17:54.265Z",
       "modified": "2026-01-16T07:34:54.265Z",
@@ -411,7 +396,6 @@
       "app_sw_version": "v4.4.91",
       "last_scanned": "2026-01-13T11:17:54.265Z",
       "last_pinged": "2026-01-16T07:34:54.265Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -427,8 +411,8 @@
       "manufacturer": "Philips",
       "model": "CT 6000 iCT",
       "serial_number": "P-2021-00017",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-02-03T09:17:54.265Z",
       "modified": "2026-01-16T08:25:54.265Z",
@@ -437,7 +421,6 @@
       "app_sw_version": "v4.2.46",
       "last_scanned": "2026-01-14T10:17:54.265Z",
       "last_pinged": "2026-01-16T08:25:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -453,8 +436,8 @@
       "manufacturer": "Philips",
       "model": "Spectral CT 7500",
       "serial_number": "P-2020-00018",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-05-12T09:17:54.265Z",
       "modified": "2026-01-16T07:23:54.265Z",
@@ -463,7 +446,6 @@
       "app_sw_version": "v1.3.2",
       "last_scanned": "2026-01-14T08:17:54.265Z",
       "last_pinged": "2026-01-16T07:23:54.265Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -479,8 +461,8 @@
       "manufacturer": "Philips",
       "model": "IQon Spectral CT",
       "serial_number": "P-2022-00019",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-12-03T09:17:54.265Z",
       "modified": "2026-01-16T08:44:54.265Z",
@@ -489,7 +471,6 @@
       "app_sw_version": "v1.0.86",
       "last_scanned": "2026-01-15T19:17:54.265Z",
       "last_pinged": "2026-01-16T08:44:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -501,12 +482,12 @@
       "hostname": "med-dev-00020.hospital.local",
       "ip_address": "192.168.35.178",
       "mac_address": "b5:06:1c:e4:98:c6",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Siemens Healthineers",
       "model": "Somatom Emotion 16",
       "serial_number": "SH-2017-00020",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-05-01T09:17:54.265Z",
       "modified": "2026-01-16T08:38:54.265Z",
@@ -515,7 +496,6 @@
       "app_sw_version": "v7.6.93",
       "last_scanned": "2026-01-13T18:17:54.265Z",
       "last_pinged": "2026-01-16T08:38:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -531,8 +511,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Somatom Perspective 16",
       "serial_number": "SH-2021-00021",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-08-06T09:17:54.265Z",
       "modified": "2026-01-16T07:53:54.265Z",
@@ -541,7 +521,6 @@
       "app_sw_version": "v10.6.55",
       "last_scanned": "2026-01-15T21:17:54.265Z",
       "last_pinged": "2026-01-16T07:53:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -557,8 +536,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "go.Now",
       "serial_number": "SH-2019-00022",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-06-02T09:17:54.265Z",
       "modified": "2026-01-16T07:30:54.265Z",
@@ -567,7 +546,6 @@
       "app_sw_version": "v14.5.68",
       "last_scanned": "2026-01-15T01:17:54.265Z",
       "last_pinged": "2026-01-16T07:30:54.265Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -583,8 +561,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Somatom Scope",
       "serial_number": "SH-2021-00023",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-05-26T09:17:54.265Z",
       "modified": "2026-01-16T08:46:54.265Z",
@@ -593,7 +571,6 @@
       "app_sw_version": "v2.2.79",
       "last_scanned": "2026-01-13T22:17:54.265Z",
       "last_pinged": "2026-01-16T08:46:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -609,8 +586,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Definition AS 20/40",
       "serial_number": "SH-2015-00024",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-09-22T09:17:54.265Z",
       "modified": "2026-01-16T08:08:54.265Z",
@@ -619,7 +596,6 @@
       "app_sw_version": "v11.0.25",
       "last_scanned": "2026-01-14T12:17:54.265Z",
       "last_pinged": "2026-01-16T08:08:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -635,8 +611,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Sensation Open 24/40",
       "serial_number": "SH-2016-00025",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-05-27T09:17:54.265Z",
       "modified": "2026-01-16T08:21:54.265Z",
@@ -645,7 +621,6 @@
       "app_sw_version": "v10.4.0",
       "last_scanned": "2026-01-15T14:17:54.265Z",
       "last_pinged": "2026-01-16T08:21:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -661,8 +636,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Sensation 16",
       "serial_number": "SH-2018-00026",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-02-15T09:17:54.265Z",
       "modified": "2026-01-16T08:20:54.265Z",
@@ -671,7 +646,6 @@
       "app_sw_version": "v13.4.51",
       "last_scanned": "2026-01-14T16:17:54.265Z",
       "last_pinged": "2026-01-16T08:20:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -687,8 +661,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Sensation 64",
       "serial_number": "SH-2021-00027",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-01-18T09:17:54.265Z",
       "modified": "2026-01-16T07:46:54.265Z",
@@ -697,7 +671,6 @@
       "app_sw_version": "v15.4.77",
       "last_scanned": "2026-01-13T14:17:54.265Z",
       "last_pinged": "2026-01-16T07:46:54.265Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -713,8 +686,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "On.site",
       "serial_number": "SH-2018-00028",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-07-13T09:17:54.265Z",
       "modified": "2026-01-16T07:27:54.265Z",
@@ -723,7 +696,6 @@
       "app_sw_version": "v3.5.37",
       "last_scanned": "2026-01-14T08:17:54.265Z",
       "last_pinged": "2026-01-16T07:27:54.265Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -739,8 +711,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Somatom Perspective 32",
       "serial_number": "SH-2022-00029",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-11-14T09:17:54.265Z",
       "modified": "2026-01-16T07:57:54.265Z",
@@ -749,7 +721,6 @@
       "app_sw_version": "v15.3.19",
       "last_scanned": "2026-01-16T01:17:54.265Z",
       "last_pinged": "2026-01-16T07:57:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"2762\"]",
       "external_keys": null
     }
   },
@@ -765,8 +736,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "go.ALL",
       "serial_number": "SH-2020-00030",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-10-19T09:17:54.265Z",
       "modified": "2026-01-16T08:13:54.265Z",
@@ -775,7 +746,6 @@
       "app_sw_version": "v14.3.11",
       "last_scanned": "2026-01-14T07:17:54.265Z",
       "last_pinged": "2026-01-16T08:13:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -787,12 +757,12 @@
       "hostname": "med-dev-00031.hospital.local",
       "ip_address": "10.208.215.179",
       "mac_address": "a7:9b:d5:e7:5e:eb",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Siemens Healthineers",
       "model": "go.Up",
       "serial_number": "SH-2016-00031",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-05-01T09:17:54.265Z",
       "modified": "2026-01-16T08:56:54.265Z",
@@ -801,7 +771,6 @@
       "app_sw_version": "v5.6.73",
       "last_scanned": "2026-01-15T00:17:54.265Z",
       "last_pinged": "2026-01-16T08:56:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"2762\"]",
       "external_keys": null
     }
   },
@@ -817,8 +786,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Definition AS 64",
       "serial_number": "SH-2022-00032",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-05-26T09:17:54.265Z",
       "modified": "2026-01-16T08:24:54.265Z",
@@ -827,7 +796,6 @@
       "app_sw_version": "v2.2.10",
       "last_scanned": "2026-01-15T07:17:54.265Z",
       "last_pinged": "2026-01-16T08:24:54.265Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -843,8 +811,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Perspective 64",
       "serial_number": "SH-2015-00033",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-04-19T09:17:54.265Z",
       "modified": "2026-01-16T07:26:54.265Z",
@@ -853,7 +821,6 @@
       "app_sw_version": "v3.4.80",
       "last_scanned": "2026-01-15T19:17:54.265Z",
       "last_pinged": "2026-01-16T07:26:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -869,8 +836,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Definition AS/AS+",
       "serial_number": "SH-2018-00034",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-01-21T09:17:54.265Z",
       "modified": "2026-01-16T07:28:54.265Z",
@@ -879,7 +846,6 @@
       "app_sw_version": "v4.9.63",
       "last_scanned": "2026-01-15T20:17:54.265Z",
       "last_pinged": "2026-01-16T07:28:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -895,8 +861,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Perspective 128",
       "serial_number": "SH-2021-00035",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-03-03T09:17:54.265Z",
       "modified": "2026-01-16T07:41:54.265Z",
@@ -905,7 +871,6 @@
       "app_sw_version": "v10.9.48",
       "last_scanned": "2026-01-13T18:17:54.265Z",
       "last_pinged": "2026-01-16T07:41:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -921,8 +886,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Definition Edge",
       "serial_number": "SH-2019-00036",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-12-21T09:17:54.265Z",
       "modified": "2026-01-16T09:03:54.265Z",
@@ -931,7 +896,6 @@
       "app_sw_version": "v11.6.82",
       "last_scanned": "2026-01-14T13:17:54.265Z",
       "last_pinged": "2026-01-16T09:03:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -947,8 +911,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Somatom X.cite",
       "serial_number": "SH-2022-00037",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-04-18T09:17:54.265Z",
       "modified": "2026-01-16T07:56:54.265Z",
@@ -957,7 +921,6 @@
       "app_sw_version": "v7.9.19",
       "last_scanned": "2026-01-13T17:17:54.265Z",
       "last_pinged": "2026-01-16T07:56:54.265Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -973,8 +936,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "SOMATOM go.Top",
       "serial_number": "SH-2016-00038",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-08-09T09:17:54.265Z",
       "modified": "2026-01-16T08:31:54.265Z",
@@ -983,7 +946,6 @@
       "app_sw_version": "v7.5.29",
       "last_scanned": "2026-01-16T05:17:54.265Z",
       "last_pinged": "2026-01-16T08:31:54.265Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -999,8 +961,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Edge Plus",
       "serial_number": "SH-2020-00039",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-02-28T09:17:54.265Z",
       "modified": "2026-01-16T08:09:54.265Z",
@@ -1009,7 +971,6 @@
       "app_sw_version": "v11.5.47",
       "last_scanned": "2026-01-16T08:17:54.265Z",
       "last_pinged": "2026-01-16T08:09:54.265Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1021,12 +982,12 @@
       "hostname": "med-dev-00040.hospital.local",
       "ip_address": "192.168.76.159",
       "mac_address": "28:0b:84:8b:5a:44",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Siemens Healthineers",
       "model": "Definition Flash",
       "serial_number": "SH-2022-00040",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-01-18T09:17:54.265Z",
       "modified": "2026-01-16T08:23:54.265Z",
@@ -1035,7 +996,6 @@
       "app_sw_version": "v2.0.14",
       "last_scanned": "2026-01-14T17:17:54.265Z",
       "last_pinged": "2026-01-16T08:23:54.265Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1047,12 +1007,12 @@
       "hostname": "med-dev-00041.hospital.local",
       "ip_address": "172.31.110.171",
       "mac_address": "b2:a1:d7:24:4a:7c",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Siemens Healthineers",
       "model": "Somatom X.ceed",
       "serial_number": "SH-2019-00041",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-03-27T09:17:54.265Z",
       "modified": "2026-01-16T08:44:54.265Z",
@@ -1061,7 +1021,6 @@
       "app_sw_version": "v2.9.50",
       "last_scanned": "2026-01-16T04:17:54.265Z",
       "last_pinged": "2026-01-16T08:44:54.265Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1077,8 +1036,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Drive",
       "serial_number": "SH-2021-00042",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-11-25T09:17:54.266Z",
       "modified": "2026-01-16T09:06:54.266Z",
@@ -1087,7 +1046,6 @@
       "app_sw_version": "v3.1.34",
       "last_scanned": "2026-01-14T17:17:54.266Z",
       "last_pinged": "2026-01-16T09:06:54.266Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1103,8 +1061,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Somatom Force",
       "serial_number": "SH-2023-00043",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-01-03T09:17:54.266Z",
       "modified": "2026-01-16T08:02:54.266Z",
@@ -1113,7 +1071,6 @@
       "app_sw_version": "v11.7.35",
       "last_scanned": "2026-01-15T19:17:54.266Z",
       "last_pinged": "2026-01-16T08:02:54.266Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1125,12 +1082,12 @@
       "hostname": "med-dev-00044.hospital.local",
       "ip_address": "172.20.204.217",
       "mac_address": "6b:8e:81:c3:b5:c4",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Siemens Healthineers",
       "model": "Somatom Confidence RT Pro",
       "serial_number": "SH-2022-00044",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-06-06T09:17:54.266Z",
       "modified": "2026-01-16T08:13:54.266Z",
@@ -1139,7 +1096,6 @@
       "app_sw_version": "v13.8.24",
       "last_scanned": "2026-01-13T15:17:54.266Z",
       "last_pinged": "2026-01-16T08:13:54.266Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -1155,8 +1111,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "NAEOTOM Alpha",
       "serial_number": "SH-2020-00045",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-02-12T09:17:54.266Z",
       "modified": "2026-01-16T08:09:54.266Z",
@@ -1165,7 +1121,6 @@
       "app_sw_version": "v6.4.21",
       "last_scanned": "2026-01-14T12:17:54.266Z",
       "last_pinged": "2026-01-16T08:09:54.266Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1181,8 +1136,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "SOMATOM Pro.Pulse",
       "serial_number": "SH-2015-00046",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-01-12T09:17:54.266Z",
       "modified": "2026-01-16T08:17:54.266Z",
@@ -1191,7 +1146,6 @@
       "app_sw_version": "v6.1.20",
       "last_scanned": "2026-01-13T22:17:54.266Z",
       "last_pinged": "2026-01-16T08:17:54.266Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1203,12 +1157,12 @@
       "hostname": "med-dev-00047.hospital.local",
       "ip_address": "172.16.161.1",
       "mac_address": "2d:bd:ea:c9:8d:e5",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "Signa LX 1.5 T",
       "serial_number": "GH-2016-00047",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-08-03T09:17:54.266Z",
       "modified": "2026-01-16T07:34:54.266Z",
@@ -1217,7 +1171,6 @@
       "app_sw_version": "v13.5.72",
       "last_scanned": "2026-01-15T02:17:54.266Z",
       "last_pinged": "2026-01-16T07:34:54.266Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1233,8 +1186,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Signa Excite 1.5 T",
       "serial_number": "GH-2018-00048",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-06-28T09:17:54.266Z",
       "modified": "2026-01-16T07:27:54.266Z",
@@ -1243,7 +1196,6 @@
       "app_sw_version": "v7.7.3",
       "last_scanned": "2026-01-16T03:17:54.266Z",
       "last_pinged": "2026-01-16T07:27:54.266Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -1259,8 +1211,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Signa Excite HD",
       "serial_number": "GH-2016-00049",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-07-05T09:17:54.266Z",
       "modified": "2026-01-16T09:01:54.266Z",
@@ -1269,7 +1221,6 @@
       "app_sw_version": "v10.9.4",
       "last_scanned": "2026-01-14T22:17:54.266Z",
       "last_pinged": "2026-01-16T09:01:54.266Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"2762\"]",
       "external_keys": null
     }
   },
@@ -1285,8 +1236,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Signa Excite HDx",
       "serial_number": "GH-2023-00050",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-04-28T09:17:54.267Z",
       "modified": "2026-01-16T08:30:54.267Z",
@@ -1295,7 +1246,6 @@
       "app_sw_version": "v2.6.44",
       "last_scanned": "2026-01-14T11:17:54.267Z",
       "last_pinged": "2026-01-16T08:30:54.267Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -1307,12 +1257,12 @@
       "hostname": "med-dev-00051.hospital.local",
       "ip_address": "172.18.35.63",
       "mac_address": "af:81:39:5a:1b:99",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "Optima 450 w 1.5 T",
       "serial_number": "GH-2018-00051",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-12-10T09:17:54.267Z",
       "modified": "2026-01-16T08:31:54.267Z",
@@ -1321,7 +1271,6 @@
       "app_sw_version": "v5.3.40",
       "last_scanned": "2026-01-14T12:17:54.267Z",
       "last_pinged": "2026-01-16T08:31:54.267Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1333,12 +1282,12 @@
       "hostname": "med-dev-00052.hospital.local",
       "ip_address": "192.168.249.95",
       "mac_address": "97:ce:83:58:03:76",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "Optima MR360 Advance",
       "serial_number": "GH-2021-00052",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-02-17T09:17:54.267Z",
       "modified": "2026-01-16T07:38:54.267Z",
@@ -1347,7 +1296,6 @@
       "app_sw_version": "v1.1.65",
       "last_scanned": "2026-01-16T03:17:54.267Z",
       "last_pinged": "2026-01-16T07:38:54.267Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1363,8 +1311,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Signa Creator",
       "serial_number": "GH-2023-00053",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-11-07T09:17:54.267Z",
       "modified": "2026-01-16T07:27:54.267Z",
@@ -1373,7 +1321,6 @@
       "app_sw_version": "v9.9.0",
       "last_scanned": "2026-01-16T03:17:54.267Z",
       "last_pinged": "2026-01-16T07:27:54.267Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -1389,8 +1336,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Signa Explorer",
       "serial_number": "GH-2021-00054",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-01-14T09:17:54.267Z",
       "modified": "2026-01-16T08:25:54.267Z",
@@ -1399,7 +1346,6 @@
       "app_sw_version": "v5.9.24",
       "last_scanned": "2026-01-15T09:17:54.267Z",
       "last_pinged": "2026-01-16T08:25:54.267Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1411,12 +1357,12 @@
       "hostname": "med-dev-00055.hospital.local",
       "ip_address": "192.168.249.158",
       "mac_address": "5f:f9:8e:67:4b:8e",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "Signa Voyager",
       "serial_number": "GH-2023-00055",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-02-28T09:17:54.267Z",
       "modified": "2026-01-16T07:20:54.267Z",
@@ -1425,7 +1371,6 @@
       "app_sw_version": "v5.5.30",
       "last_scanned": "2026-01-16T03:17:54.267Z",
       "last_pinged": "2026-01-16T07:20:54.267Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -1437,12 +1382,12 @@
       "hostname": "med-dev-00056.hospital.local",
       "ip_address": "10.118.78.29",
       "mac_address": "76:94:1a:c5:57:6c",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "Signa Artist",
       "serial_number": "GH-2021-00056",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-05-15T09:17:54.267Z",
       "modified": "2026-01-16T07:46:54.267Z",
@@ -1451,7 +1396,6 @@
       "app_sw_version": "v13.7.20",
       "last_scanned": "2026-01-16T08:17:54.267Z",
       "last_pinged": "2026-01-16T07:46:54.267Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -1463,12 +1407,12 @@
       "hostname": "med-dev-00057.hospital.local",
       "ip_address": "172.17.146.245",
       "mac_address": "66:24:0f:f5:b9:5d",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "Signa Victor",
       "serial_number": "GH-2018-00057",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-10-20T09:17:54.267Z",
       "modified": "2026-01-16T07:26:54.267Z",
@@ -1477,7 +1421,6 @@
       "app_sw_version": "v5.9.64",
       "last_scanned": "2026-01-15T09:17:54.267Z",
       "last_pinged": "2026-01-16T07:26:54.267Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1493,8 +1436,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Artist EVO",
       "serial_number": "GH-2021-00058",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-12-04T09:17:54.267Z",
       "modified": "2026-01-16T08:15:54.267Z",
@@ -1503,7 +1446,6 @@
       "app_sw_version": "v7.6.61",
       "last_scanned": "2026-01-14T00:17:54.267Z",
       "last_pinged": "2026-01-16T08:15:54.267Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1519,8 +1461,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "MAGNETOM Essenza",
       "serial_number": "SH-2019-00059",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-10-07T09:17:54.267Z",
       "modified": "2026-01-16T08:05:54.267Z",
@@ -1529,7 +1471,6 @@
       "app_sw_version": "v10.4.2",
       "last_scanned": "2026-01-16T07:17:54.267Z",
       "last_pinged": "2026-01-16T08:05:54.267Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1541,12 +1482,12 @@
       "hostname": "med-dev-00060.hospital.local",
       "ip_address": "10.210.74.83",
       "mac_address": "a5:ab:44:a8:c5:ca",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Siemens Healthineers",
       "model": "MAGNETOM Amira",
       "serial_number": "SH-2016-00060",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-04-03T09:17:54.267Z",
       "modified": "2026-01-16T07:43:54.267Z",
@@ -1555,7 +1496,6 @@
       "app_sw_version": "v11.0.77",
       "last_scanned": "2026-01-15T23:17:54.267Z",
       "last_pinged": "2026-01-16T07:43:54.267Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1567,12 +1507,12 @@
       "hostname": "med-dev-00061.hospital.local",
       "ip_address": "10.229.202.121",
       "mac_address": "9e:c8:5d:6a:fb:4c",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Siemens Healthineers",
       "model": "MAGNETOM Altea",
       "serial_number": "SH-2017-00061",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-03-19T09:17:54.267Z",
       "modified": "2026-01-16T07:52:54.267Z",
@@ -1581,7 +1521,6 @@
       "app_sw_version": "v15.6.47",
       "last_scanned": "2026-01-16T04:17:54.267Z",
       "last_pinged": "2026-01-16T07:52:54.267Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1597,8 +1536,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "MAGNETOM Sola",
       "serial_number": "SH-2023-00062",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-07-09T09:17:54.267Z",
       "modified": "2026-01-16T07:55:54.267Z",
@@ -1607,7 +1546,6 @@
       "app_sw_version": "v2.8.56",
       "last_scanned": "2026-01-15T08:17:54.267Z",
       "last_pinged": "2026-01-16T07:55:54.267Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1619,12 +1557,12 @@
       "hostname": "med-dev-00063.hospital.local",
       "ip_address": "172.17.93.243",
       "mac_address": "22:d6:70:be:12:c3",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Siemens Healthineers",
       "model": "MAGNETOM Aera",
       "serial_number": "SH-2016-00063",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-11-25T09:17:54.267Z",
       "modified": "2026-01-16T08:09:54.267Z",
@@ -1633,7 +1571,6 @@
       "app_sw_version": "v8.6.69",
       "last_scanned": "2026-01-13T12:17:54.267Z",
       "last_pinged": "2026-01-16T08:09:54.267Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -1649,8 +1586,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "MAGNETOM Lumina",
       "serial_number": "SH-2022-00064",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-02-01T09:17:54.267Z",
       "modified": "2026-01-16T08:09:54.267Z",
@@ -1659,7 +1596,6 @@
       "app_sw_version": "v10.1.0",
       "last_scanned": "2026-01-14T12:17:54.267Z",
       "last_pinged": "2026-01-16T08:09:54.267Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1675,8 +1611,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "MAGNETOM Vida",
       "serial_number": "SH-2020-00065",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-12-15T09:17:54.267Z",
       "modified": "2026-01-16T08:09:54.267Z",
@@ -1685,7 +1621,6 @@
       "app_sw_version": "v1.8.96",
       "last_scanned": "2026-01-14T15:17:54.267Z",
       "last_pinged": "2026-01-16T08:09:54.267Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1701,8 +1636,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "MAGNETOM Skyra",
       "serial_number": "SH-2019-00066",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-04-20T09:17:54.267Z",
       "modified": "2026-01-16T08:49:54.267Z",
@@ -1711,7 +1646,6 @@
       "app_sw_version": "v14.0.29",
       "last_scanned": "2026-01-14T06:17:54.267Z",
       "last_pinged": "2026-01-16T08:49:54.267Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -1727,8 +1661,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "MAGNETOM Prisma",
       "serial_number": "SH-2023-00067",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-03-09T09:17:54.267Z",
       "modified": "2026-01-16T07:38:54.267Z",
@@ -1737,7 +1671,6 @@
       "app_sw_version": "v8.0.76",
       "last_scanned": "2026-01-15T16:17:54.267Z",
       "last_pinged": "2026-01-16T07:38:54.267Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1749,12 +1682,12 @@
       "hostname": "med-dev-00068.hospital.local",
       "ip_address": "172.20.60.181",
       "mac_address": "74:00:32:c5:5f:5f",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Siemens Healthineers",
       "model": "MAGNETOM Terra",
       "serial_number": "SH-2023-00068",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-08-28T09:17:54.267Z",
       "modified": "2026-01-16T07:27:54.267Z",
@@ -1763,7 +1696,6 @@
       "app_sw_version": "v11.7.90",
       "last_scanned": "2026-01-14T19:17:54.267Z",
       "last_pinged": "2026-01-16T07:27:54.267Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -1779,8 +1711,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Voluson E6",
       "serial_number": "GH-2023-00069",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-04-10T09:17:54.267Z",
       "modified": "2026-01-16T08:08:54.267Z",
@@ -1789,7 +1721,6 @@
       "app_sw_version": "v4.3.9",
       "last_scanned": "2026-01-15T06:17:54.267Z",
       "last_pinged": "2026-01-16T08:08:54.267Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -1805,8 +1736,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Voluson E8",
       "serial_number": "GH-2021-00070",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-06-14T09:17:54.268Z",
       "modified": "2026-01-16T07:46:54.268Z",
@@ -1815,7 +1746,6 @@
       "app_sw_version": "v5.4.31",
       "last_scanned": "2026-01-15T00:17:54.268Z",
       "last_pinged": "2026-01-16T07:46:54.268Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -1831,8 +1761,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Voluson E10",
       "serial_number": "GH-2022-00071",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-07-21T09:17:54.268Z",
       "modified": "2026-01-16T08:38:54.268Z",
@@ -1841,7 +1771,6 @@
       "app_sw_version": "v11.3.70",
       "last_scanned": "2026-01-14T22:17:54.268Z",
       "last_pinged": "2026-01-16T08:38:54.268Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -1857,8 +1786,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Voluson S6",
       "serial_number": "GH-2022-00072",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-11-04T09:17:54.268Z",
       "modified": "2026-01-16T09:03:54.268Z",
@@ -1867,7 +1796,6 @@
       "app_sw_version": "v10.0.41",
       "last_scanned": "2026-01-15T06:17:54.268Z",
       "last_pinged": "2026-01-16T09:03:54.268Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -1883,8 +1811,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Voluson S8",
       "serial_number": "GH-2017-00073",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-02-16T09:17:54.268Z",
       "modified": "2026-01-16T07:24:54.268Z",
@@ -1893,7 +1821,6 @@
       "app_sw_version": "v4.6.57",
       "last_scanned": "2026-01-14T04:17:54.268Z",
       "last_pinged": "2026-01-16T07:24:54.268Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -1909,8 +1836,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Voluson S10",
       "serial_number": "GH-2022-00074",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-07-10T09:17:54.268Z",
       "modified": "2026-01-16T07:58:54.268Z",
@@ -1919,7 +1846,6 @@
       "app_sw_version": "v4.6.82",
       "last_scanned": "2026-01-13T11:17:54.268Z",
       "last_pinged": "2026-01-16T07:58:54.268Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -1935,8 +1861,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Voluson P6",
       "serial_number": "GH-2019-00075",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-04-01T09:17:54.268Z",
       "modified": "2026-01-16T08:21:54.268Z",
@@ -1945,7 +1871,6 @@
       "app_sw_version": "v3.7.59",
       "last_scanned": "2026-01-14T02:17:54.268Z",
       "last_pinged": "2026-01-16T08:21:54.268Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -1961,8 +1886,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Voluson P8",
       "serial_number": "GH-2019-00076",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-04-21T09:17:54.268Z",
       "modified": "2026-01-16T08:05:54.268Z",
@@ -1971,7 +1896,6 @@
       "app_sw_version": "v13.8.77",
       "last_scanned": "2026-01-14T11:17:54.268Z",
       "last_pinged": "2026-01-16T08:05:54.268Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -1987,8 +1911,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Voluson I",
       "serial_number": "GH-2021-00077",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-11-25T09:17:54.268Z",
       "modified": "2026-01-16T08:15:54.268Z",
@@ -1997,7 +1921,6 @@
       "app_sw_version": "v7.7.29",
       "last_scanned": "2026-01-14T12:17:54.268Z",
       "last_pinged": "2026-01-16T08:15:54.268Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2013,8 +1936,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Voluson E",
       "serial_number": "GH-2017-00078",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-06-15T09:17:54.268Z",
       "modified": "2026-01-16T08:56:54.268Z",
@@ -2023,7 +1946,6 @@
       "app_sw_version": "v1.6.92",
       "last_scanned": "2026-01-15T11:17:54.268Z",
       "last_pinged": "2026-01-16T08:56:54.268Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2039,8 +1961,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Logiq E10",
       "serial_number": "GH-2016-00079",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-01-19T09:17:54.268Z",
       "modified": "2026-01-16T08:52:54.268Z",
@@ -2049,7 +1971,6 @@
       "app_sw_version": "v13.9.16",
       "last_scanned": "2026-01-14T01:17:54.268Z",
       "last_pinged": "2026-01-16T08:52:54.268Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2065,8 +1986,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Logiq E9",
       "serial_number": "GH-2020-00080",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-01-21T09:17:54.268Z",
       "modified": "2026-01-16T08:45:54.268Z",
@@ -2075,7 +1996,6 @@
       "app_sw_version": "v1.1.10",
       "last_scanned": "2026-01-15T11:17:54.268Z",
       "last_pinged": "2026-01-16T08:45:54.268Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2091,8 +2011,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Logiq S8",
       "serial_number": "GH-2015-00081",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-09-25T09:17:54.268Z",
       "modified": "2026-01-16T08:50:54.268Z",
@@ -2101,7 +2021,6 @@
       "app_sw_version": "v8.2.21",
       "last_scanned": "2026-01-14T15:17:54.268Z",
       "last_pinged": "2026-01-16T08:50:54.268Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2117,8 +2036,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Logiq S8 XDClear 2.0",
       "serial_number": "GH-2019-00082",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-04-08T09:17:54.268Z",
       "modified": "2026-01-16T08:41:54.268Z",
@@ -2127,7 +2046,6 @@
       "app_sw_version": "v11.5.36",
       "last_scanned": "2026-01-15T14:17:54.268Z",
       "last_pinged": "2026-01-16T08:41:54.268Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2143,8 +2061,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Logiq S7",
       "serial_number": "GH-2016-00083",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-03-01T09:17:54.268Z",
       "modified": "2026-01-16T09:11:54.268Z",
@@ -2153,7 +2071,6 @@
       "app_sw_version": "v8.6.82",
       "last_scanned": "2026-01-13T20:17:54.268Z",
       "last_pinged": "2026-01-16T09:11:54.268Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2165,12 +2082,12 @@
       "hostname": "med-dev-00084.hospital.local",
       "ip_address": "192.168.5.57",
       "mac_address": "44:09:35:fc:95:92",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "Logiq P6",
       "serial_number": "GH-2020-00084",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-03-12T09:17:54.269Z",
       "modified": "2026-01-16T08:47:54.269Z",
@@ -2179,7 +2096,6 @@
       "app_sw_version": "v10.7.55",
       "last_scanned": "2026-01-15T03:17:54.269Z",
       "last_pinged": "2026-01-16T08:47:54.269Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2195,8 +2111,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Logiq P7",
       "serial_number": "GH-2018-00085",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-02-27T09:17:54.269Z",
       "modified": "2026-01-16T07:17:54.269Z",
@@ -2205,7 +2121,6 @@
       "app_sw_version": "v1.8.86",
       "last_scanned": "2026-01-13T17:17:54.269Z",
       "last_pinged": "2026-01-16T07:17:54.269Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2221,8 +2136,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Logiq P9",
       "serial_number": "GH-2015-00086",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-03-17T09:17:54.269Z",
       "modified": "2026-01-16T08:46:54.269Z",
@@ -2231,7 +2146,6 @@
       "app_sw_version": "v2.8.21",
       "last_scanned": "2026-01-14T09:17:54.269Z",
       "last_pinged": "2026-01-16T08:46:54.269Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2247,8 +2161,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Logiq F6",
       "serial_number": "GH-2016-00087",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-02-11T09:17:54.269Z",
       "modified": "2026-01-16T08:33:54.269Z",
@@ -2257,7 +2171,6 @@
       "app_sw_version": "v11.0.99",
       "last_scanned": "2026-01-15T11:17:54.269Z",
       "last_pinged": "2026-01-16T08:33:54.269Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2269,12 +2182,12 @@
       "hostname": "med-dev-00088.hospital.local",
       "ip_address": "172.21.142.121",
       "mac_address": "32:71:bc:a1:06:a3",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "Logiq E",
       "serial_number": "GH-2015-00088",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-11-03T09:17:54.269Z",
       "modified": "2026-01-16T08:07:54.269Z",
@@ -2283,7 +2196,6 @@
       "app_sw_version": "v8.0.17",
       "last_scanned": "2026-01-15T07:17:54.269Z",
       "last_pinged": "2026-01-16T08:07:54.269Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2299,8 +2211,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Vivid E90",
       "serial_number": "GH-2018-00089",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-06-08T09:17:54.269Z",
       "modified": "2026-01-16T08:53:54.269Z",
@@ -2309,7 +2221,6 @@
       "app_sw_version": "v15.4.66",
       "last_scanned": "2026-01-14T13:17:54.269Z",
       "last_pinged": "2026-01-16T08:53:54.269Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2325,8 +2236,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Vivid E95",
       "serial_number": "GH-2016-00090",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-09-23T09:17:54.269Z",
       "modified": "2026-01-16T08:39:54.269Z",
@@ -2335,7 +2246,6 @@
       "app_sw_version": "v10.7.89",
       "last_scanned": "2026-01-15T11:17:54.269Z",
       "last_pinged": "2026-01-16T08:39:54.269Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2351,8 +2261,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Vivid E95 Ultra Edition",
       "serial_number": "GH-2018-00091",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-09-29T09:17:54.269Z",
       "modified": "2026-01-16T08:38:54.269Z",
@@ -2361,7 +2271,6 @@
       "app_sw_version": "v2.0.89",
       "last_scanned": "2026-01-13T22:17:54.269Z",
       "last_pinged": "2026-01-16T08:38:54.269Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2377,8 +2286,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Vivid E9",
       "serial_number": "GH-2015-00092",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-05-27T09:17:54.269Z",
       "modified": "2026-01-16T08:57:54.269Z",
@@ -2387,7 +2296,6 @@
       "app_sw_version": "v3.0.39",
       "last_scanned": "2026-01-13T23:17:54.269Z",
       "last_pinged": "2026-01-16T08:57:54.269Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2403,8 +2311,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Vivid T8",
       "serial_number": "GH-2017-00093",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-01-21T09:17:54.269Z",
       "modified": "2026-01-16T08:13:54.269Z",
@@ -2413,7 +2321,6 @@
       "app_sw_version": "v1.1.7",
       "last_scanned": "2026-01-15T19:17:54.269Z",
       "last_pinged": "2026-01-16T08:13:54.269Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2429,8 +2336,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Vivid S5",
       "serial_number": "GH-2023-00094",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-11-07T09:17:54.269Z",
       "modified": "2026-01-16T07:39:54.269Z",
@@ -2439,7 +2346,6 @@
       "app_sw_version": "v12.5.3",
       "last_scanned": "2026-01-13T22:17:54.269Z",
       "last_pinged": "2026-01-16T07:39:54.269Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2455,8 +2361,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Vivid S6",
       "serial_number": "GH-2018-00095",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-12-11T09:17:54.269Z",
       "modified": "2026-01-16T07:44:54.269Z",
@@ -2465,7 +2371,6 @@
       "app_sw_version": "v7.8.8",
       "last_scanned": "2026-01-15T23:17:54.269Z",
       "last_pinged": "2026-01-16T07:44:54.269Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2481,8 +2386,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Vivid S60",
       "serial_number": "GH-2015-00096",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-03-09T09:17:54.269Z",
       "modified": "2026-01-16T07:26:54.269Z",
@@ -2491,7 +2396,6 @@
       "app_sw_version": "v2.5.43",
       "last_scanned": "2026-01-15T07:17:54.269Z",
       "last_pinged": "2026-01-16T07:26:54.269Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2507,8 +2411,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Vivid S60N",
       "serial_number": "GH-2015-00097",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-05-20T09:17:54.269Z",
       "modified": "2026-01-16T08:37:54.269Z",
@@ -2517,7 +2421,6 @@
       "app_sw_version": "v14.3.85",
       "last_scanned": "2026-01-15T08:17:54.269Z",
       "last_pinged": "2026-01-16T08:37:54.269Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2529,12 +2432,12 @@
       "hostname": "med-dev-00098.hospital.local",
       "ip_address": "192.168.80.8",
       "mac_address": "7d:4d:2a:18:b2:ee",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "Vivid S70",
       "serial_number": "GH-2022-00098",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-12-17T09:17:54.270Z",
       "modified": "2026-01-16T09:08:54.270Z",
@@ -2543,7 +2446,6 @@
       "app_sw_version": "v10.3.41",
       "last_scanned": "2026-01-14T11:17:54.270Z",
       "last_pinged": "2026-01-16T09:08:54.270Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2559,8 +2461,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Vivid S70N",
       "serial_number": "GH-2022-00099",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-12-30T09:17:54.270Z",
       "modified": "2026-01-16T07:27:54.270Z",
@@ -2569,7 +2471,6 @@
       "app_sw_version": "v11.7.7",
       "last_scanned": "2026-01-14T02:17:54.270Z",
       "last_pinged": "2026-01-16T07:27:54.270Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2585,8 +2486,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Vivid IQ",
       "serial_number": "GH-2016-00100",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-06-29T09:17:54.270Z",
       "modified": "2026-01-16T09:12:54.270Z",
@@ -2595,7 +2496,6 @@
       "app_sw_version": "v6.2.38",
       "last_scanned": "2026-01-13T18:17:54.270Z",
       "last_pinged": "2026-01-16T09:12:54.270Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2607,12 +2507,12 @@
       "hostname": "med-dev-00101.hospital.local",
       "ip_address": "172.29.72.16",
       "mac_address": "3c:1a:a0:a1:34:be",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "Vivid I",
       "serial_number": "GH-2023-00101",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-10-18T09:17:54.270Z",
       "modified": "2026-01-16T08:27:54.270Z",
@@ -2621,7 +2521,6 @@
       "app_sw_version": "v9.8.44",
       "last_scanned": "2026-01-14T17:17:54.270Z",
       "last_pinged": "2026-01-16T08:27:54.270Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2637,8 +2536,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Vivid Q",
       "serial_number": "GH-2015-00102",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-09-23T09:17:54.270Z",
       "modified": "2026-01-16T08:34:54.270Z",
@@ -2647,7 +2546,6 @@
       "app_sw_version": "v5.0.91",
       "last_scanned": "2026-01-14T19:17:54.270Z",
       "last_pinged": "2026-01-16T08:34:54.270Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2663,8 +2561,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Venue GO",
       "serial_number": "GH-2016-00103",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-05-23T09:17:54.270Z",
       "modified": "2026-01-16T08:51:54.270Z",
@@ -2673,7 +2571,6 @@
       "app_sw_version": "v6.9.63",
       "last_scanned": "2026-01-15T09:17:54.270Z",
       "last_pinged": "2026-01-16T08:51:54.270Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2689,8 +2586,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Venue 50",
       "serial_number": "GH-2017-00104",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-05-19T09:17:54.270Z",
       "modified": "2026-01-16T08:55:54.270Z",
@@ -2699,7 +2596,6 @@
       "app_sw_version": "v9.5.54",
       "last_scanned": "2026-01-14T20:17:54.270Z",
       "last_pinged": "2026-01-16T08:55:54.270Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2711,12 +2607,12 @@
       "hostname": "med-dev-00105.hospital.local",
       "ip_address": "192.168.110.15",
       "mac_address": "b0:8b:10:c9:44:4e",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "Versana Premier",
       "serial_number": "GH-2020-00105",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-02-25T09:17:54.270Z",
       "modified": "2026-01-16T08:31:54.270Z",
@@ -2725,7 +2621,6 @@
       "app_sw_version": "v1.5.14",
       "last_scanned": "2026-01-14T13:17:54.270Z",
       "last_pinged": "2026-01-16T08:31:54.270Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2741,8 +2636,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Versana Active",
       "serial_number": "GH-2017-00106",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-02-12T09:17:54.270Z",
       "modified": "2026-01-16T08:26:54.270Z",
@@ -2751,7 +2646,6 @@
       "app_sw_version": "v12.8.27",
       "last_scanned": "2026-01-14T13:17:54.270Z",
       "last_pinged": "2026-01-16T08:26:54.270Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2767,8 +2661,8 @@
       "manufacturer": "Philips",
       "model": "Affiniti 70",
       "serial_number": "P-2018-00107",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-09-13T09:17:54.270Z",
       "modified": "2026-01-16T07:17:54.270Z",
@@ -2777,7 +2671,6 @@
       "app_sw_version": "v2.0.78",
       "last_scanned": "2026-01-15T23:17:54.270Z",
       "last_pinged": "2026-01-16T07:17:54.270Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2793,8 +2686,8 @@
       "manufacturer": "Philips",
       "model": "Affiniti 50",
       "serial_number": "P-2016-00108",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-01-17T09:17:54.270Z",
       "modified": "2026-01-16T07:34:54.270Z",
@@ -2803,7 +2696,6 @@
       "app_sw_version": "v12.4.27",
       "last_scanned": "2026-01-15T19:17:54.270Z",
       "last_pinged": "2026-01-16T07:34:54.270Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2819,8 +2711,8 @@
       "manufacturer": "Philips",
       "model": "ClearVue 850",
       "serial_number": "P-2023-00109",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-09-18T09:17:54.270Z",
       "modified": "2026-01-16T07:47:54.270Z",
@@ -2829,7 +2721,6 @@
       "app_sw_version": "v5.1.39",
       "last_scanned": "2026-01-13T20:17:54.270Z",
       "last_pinged": "2026-01-16T07:47:54.270Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2845,8 +2736,8 @@
       "manufacturer": "Philips",
       "model": "ClearVue 650",
       "serial_number": "P-2017-00110",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-11-06T09:17:54.271Z",
       "modified": "2026-01-16T08:41:54.271Z",
@@ -2855,7 +2746,6 @@
       "app_sw_version": "v7.4.24",
       "last_scanned": "2026-01-14T12:17:54.271Z",
       "last_pinged": "2026-01-16T08:41:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2871,8 +2761,8 @@
       "manufacturer": "Philips",
       "model": "ClearVue 550",
       "serial_number": "P-2023-00111",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-11-20T09:17:54.271Z",
       "modified": "2026-01-16T08:24:54.271Z",
@@ -2881,7 +2771,6 @@
       "app_sw_version": "v4.2.16",
       "last_scanned": "2026-01-13T14:17:54.271Z",
       "last_pinged": "2026-01-16T08:24:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2897,8 +2786,8 @@
       "manufacturer": "Philips",
       "model": "ClearVue 350",
       "serial_number": "P-2018-00112",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-01-27T09:17:54.271Z",
       "modified": "2026-01-16T07:26:54.271Z",
@@ -2907,7 +2796,6 @@
       "app_sw_version": "v14.9.64",
       "last_scanned": "2026-01-14T07:17:54.271Z",
       "last_pinged": "2026-01-16T07:26:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2923,8 +2811,8 @@
       "manufacturer": "Philips",
       "model": "Sparq",
       "serial_number": "P-2019-00113",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-07-17T09:17:54.271Z",
       "modified": "2026-01-16T08:24:54.271Z",
@@ -2933,7 +2821,6 @@
       "app_sw_version": "v4.2.56",
       "last_scanned": "2026-01-13T15:17:54.271Z",
       "last_pinged": "2026-01-16T08:24:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2949,8 +2836,8 @@
       "manufacturer": "Philips",
       "model": "HD5",
       "serial_number": "P-2023-00114",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-01-18T09:17:54.271Z",
       "modified": "2026-01-16T08:08:54.271Z",
@@ -2959,7 +2846,6 @@
       "app_sw_version": "v6.7.29",
       "last_scanned": "2026-01-15T01:17:54.271Z",
       "last_pinged": "2026-01-16T08:08:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -2975,8 +2861,8 @@
       "manufacturer": "Philips",
       "model": "HD15",
       "serial_number": "P-2019-00115",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-02-29T09:17:54.271Z",
       "modified": "2026-01-16T08:19:54.271Z",
@@ -2985,7 +2871,6 @@
       "app_sw_version": "v1.8.59",
       "last_scanned": "2026-01-14T18:17:54.271Z",
       "last_pinged": "2026-01-16T08:19:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3001,8 +2886,8 @@
       "manufacturer": "Philips",
       "model": "HD11xe",
       "serial_number": "P-2017-00116",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-12-25T09:17:54.271Z",
       "modified": "2026-01-16T07:31:54.271Z",
@@ -3011,7 +2896,6 @@
       "app_sw_version": "v8.8.19",
       "last_scanned": "2026-01-14T06:17:54.271Z",
       "last_pinged": "2026-01-16T07:31:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3023,12 +2907,12 @@
       "hostname": "med-dev-00117.hospital.local",
       "ip_address": "192.168.52.5",
       "mac_address": "5b:c2:bd:de:37:78",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Philips",
       "model": "Epiq 5",
       "serial_number": "P-2021-00117",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-09-27T09:17:54.271Z",
       "modified": "2026-01-16T08:54:54.271Z",
@@ -3037,7 +2921,6 @@
       "app_sw_version": "v11.1.38",
       "last_scanned": "2026-01-14T22:17:54.271Z",
       "last_pinged": "2026-01-16T08:54:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3053,8 +2936,8 @@
       "manufacturer": "Philips",
       "model": "Epiq 7",
       "serial_number": "P-2017-00118",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-05-19T09:17:54.271Z",
       "modified": "2026-01-16T08:07:54.271Z",
@@ -3063,7 +2946,6 @@
       "app_sw_version": "v10.7.82",
       "last_scanned": "2026-01-14T10:17:54.271Z",
       "last_pinged": "2026-01-16T08:07:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3079,8 +2961,8 @@
       "manufacturer": "Philips",
       "model": "CX50",
       "serial_number": "P-2015-00119",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-07-31T09:17:54.271Z",
       "modified": "2026-01-16T08:53:54.271Z",
@@ -3089,7 +2971,6 @@
       "app_sw_version": "v7.6.10",
       "last_scanned": "2026-01-14T15:17:54.271Z",
       "last_pinged": "2026-01-16T08:53:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3105,8 +2986,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Acuson X150",
       "serial_number": "SH-2016-00120",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-03-16T09:17:54.271Z",
       "modified": "2026-01-16T07:23:54.271Z",
@@ -3115,7 +2996,6 @@
       "app_sw_version": "v11.4.64",
       "last_scanned": "2026-01-15T23:17:54.271Z",
       "last_pinged": "2026-01-16T07:23:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3131,8 +3011,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Acuson X300",
       "serial_number": "SH-2020-00121",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-02-15T09:17:54.271Z",
       "modified": "2026-01-16T07:40:54.271Z",
@@ -3141,7 +3021,6 @@
       "app_sw_version": "v7.2.79",
       "last_scanned": "2026-01-15T12:17:54.271Z",
       "last_pinged": "2026-01-16T07:40:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3157,8 +3036,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Acuson X300 PE",
       "serial_number": "SH-2020-00122",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-02-02T09:17:54.271Z",
       "modified": "2026-01-16T09:09:54.271Z",
@@ -3167,7 +3046,6 @@
       "app_sw_version": "v8.6.33",
       "last_scanned": "2026-01-15T14:17:54.271Z",
       "last_pinged": "2026-01-16T09:09:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3183,8 +3061,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Acuson X600",
       "serial_number": "SH-2015-00123",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-03-24T09:17:54.271Z",
       "modified": "2026-01-16T08:35:54.271Z",
@@ -3193,7 +3071,6 @@
       "app_sw_version": "v1.3.72",
       "last_scanned": "2026-01-13T11:17:54.271Z",
       "last_pinged": "2026-01-16T08:35:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3209,8 +3086,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Acuson X700",
       "serial_number": "SH-2016-00124",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-02-17T09:17:54.271Z",
       "modified": "2026-01-16T07:48:54.271Z",
@@ -3219,7 +3096,6 @@
       "app_sw_version": "v1.1.61",
       "last_scanned": "2026-01-15T13:17:54.271Z",
       "last_pinged": "2026-01-16T07:48:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3231,12 +3107,12 @@
       "hostname": "med-dev-00125.hospital.local",
       "ip_address": "192.168.204.1",
       "mac_address": "8e:ce:45:da:c1:f4",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Siemens Healthineers",
       "model": "Acuson S1000",
       "serial_number": "SH-2015-00125",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-03-25T09:17:54.271Z",
       "modified": "2026-01-16T07:29:54.271Z",
@@ -3245,7 +3121,6 @@
       "app_sw_version": "v13.1.63",
       "last_scanned": "2026-01-14T13:17:54.271Z",
       "last_pinged": "2026-01-16T07:29:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3261,8 +3136,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Acuson S2000",
       "serial_number": "SH-2015-00126",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-02-14T09:17:54.271Z",
       "modified": "2026-01-16T07:58:54.271Z",
@@ -3271,7 +3146,6 @@
       "app_sw_version": "v7.5.64",
       "last_scanned": "2026-01-14T17:17:54.271Z",
       "last_pinged": "2026-01-16T07:58:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3287,8 +3161,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Acuson S3000",
       "serial_number": "SH-2017-00127",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-10-23T09:17:54.271Z",
       "modified": "2026-01-16T08:03:54.271Z",
@@ -3297,7 +3171,6 @@
       "app_sw_version": "v10.7.86",
       "last_scanned": "2026-01-15T22:17:54.271Z",
       "last_pinged": "2026-01-16T08:03:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3309,12 +3182,12 @@
       "hostname": "med-dev-00128.hospital.local",
       "ip_address": "10.42.58.31",
       "mac_address": "68:40:f1:1f:42:29",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Siemens Healthineers",
       "model": "Acuson SC2000",
       "serial_number": "SH-2023-00128",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-05-22T09:17:54.271Z",
       "modified": "2026-01-16T08:27:54.271Z",
@@ -3323,7 +3196,6 @@
       "app_sw_version": "v6.9.97",
       "last_scanned": "2026-01-15T23:17:54.271Z",
       "last_pinged": "2026-01-16T08:27:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3339,8 +3211,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Acuson Sequoia",
       "serial_number": "SH-2022-00129",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-05-02T09:17:54.271Z",
       "modified": "2026-01-16T08:43:54.271Z",
@@ -3349,7 +3221,6 @@
       "app_sw_version": "v6.9.34",
       "last_scanned": "2026-01-13T14:17:54.271Z",
       "last_pinged": "2026-01-16T08:43:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3361,12 +3232,12 @@
       "hostname": "med-dev-00130.hospital.local",
       "ip_address": "10.44.90.254",
       "mac_address": "f2:80:88:e8:15:8a",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Siemens Healthineers",
       "model": "Acuson Redwood",
       "serial_number": "SH-2023-00130",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-12-23T09:17:54.271Z",
       "modified": "2026-01-16T08:06:54.271Z",
@@ -3375,7 +3246,6 @@
       "app_sw_version": "v6.3.75",
       "last_scanned": "2026-01-16T05:17:54.271Z",
       "last_pinged": "2026-01-16T08:06:54.271Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3391,8 +3261,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Acuson Juniper",
       "serial_number": "SH-2020-00131",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-05-06T09:17:54.272Z",
       "modified": "2026-01-16T07:29:54.272Z",
@@ -3401,7 +3271,6 @@
       "app_sw_version": "v8.4.99",
       "last_scanned": "2026-01-15T03:17:54.272Z",
       "last_pinged": "2026-01-16T07:29:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3417,8 +3286,8 @@
       "manufacturer": "Canon/Toshiba",
       "model": "Xario 200",
       "serial_number": "C-2018-00132",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-08-15T09:17:54.272Z",
       "modified": "2026-01-16T07:34:54.272Z",
@@ -3427,7 +3296,6 @@
       "app_sw_version": "v11.7.92",
       "last_scanned": "2026-01-14T04:17:54.272Z",
       "last_pinged": "2026-01-16T07:34:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3443,8 +3311,8 @@
       "manufacturer": "Canon/Toshiba",
       "model": "Xario 200 g",
       "serial_number": "C-2016-00133",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-11-06T09:17:54.272Z",
       "modified": "2026-01-16T08:46:54.272Z",
@@ -3453,7 +3321,6 @@
       "app_sw_version": "v13.8.52",
       "last_scanned": "2026-01-16T00:17:54.272Z",
       "last_pinged": "2026-01-16T08:46:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3469,8 +3336,8 @@
       "manufacturer": "Canon/Toshiba",
       "model": "Xario 100 g",
       "serial_number": "C-2020-00134",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-04-22T09:17:54.272Z",
       "modified": "2026-01-16T08:25:54.272Z",
@@ -3479,7 +3346,6 @@
       "app_sw_version": "v13.2.71",
       "last_scanned": "2026-01-15T04:17:54.272Z",
       "last_pinged": "2026-01-16T08:25:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3495,8 +3361,8 @@
       "manufacturer": "Canon/Toshiba",
       "model": "Xario 100 MX",
       "serial_number": "C-2022-00135",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-07-16T09:17:54.272Z",
       "modified": "2026-01-16T08:19:54.272Z",
@@ -3505,7 +3371,6 @@
       "app_sw_version": "v12.3.63",
       "last_scanned": "2026-01-15T00:17:54.272Z",
       "last_pinged": "2026-01-16T08:19:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3521,8 +3386,8 @@
       "manufacturer": "Canon/Toshiba",
       "model": "Aplio 300",
       "serial_number": "C-2021-00136",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-12-31T09:17:54.272Z",
       "modified": "2026-01-16T08:57:54.272Z",
@@ -3531,7 +3396,6 @@
       "app_sw_version": "v5.6.71",
       "last_scanned": "2026-01-13T11:17:54.272Z",
       "last_pinged": "2026-01-16T08:57:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3547,8 +3411,8 @@
       "manufacturer": "Canon/Toshiba",
       "model": "Aplio 400",
       "serial_number": "C-2022-00137",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-10-31T09:17:54.272Z",
       "modified": "2026-01-16T08:15:54.272Z",
@@ -3557,7 +3421,6 @@
       "app_sw_version": "v10.4.61",
       "last_scanned": "2026-01-14T14:17:54.272Z",
       "last_pinged": "2026-01-16T08:15:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3573,8 +3436,8 @@
       "manufacturer": "Canon/Toshiba",
       "model": "Aplio 500",
       "serial_number": "C-2018-00138",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-05-18T09:17:54.272Z",
       "modified": "2026-01-16T08:35:54.272Z",
@@ -3583,7 +3446,6 @@
       "app_sw_version": "v13.7.38",
       "last_scanned": "2026-01-13T14:17:54.272Z",
       "last_pinged": "2026-01-16T08:35:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3595,12 +3457,12 @@
       "hostname": "med-dev-00139.hospital.local",
       "ip_address": "172.31.117.253",
       "mac_address": "5c:0f:87:65:a7:90",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Canon/Toshiba",
       "model": "Aplio 500 Platinum",
       "serial_number": "C-2016-00139",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-04-02T09:17:54.272Z",
       "modified": "2026-01-16T09:09:54.272Z",
@@ -3609,7 +3471,6 @@
       "app_sw_version": "v8.8.14",
       "last_scanned": "2026-01-15T06:17:54.272Z",
       "last_pinged": "2026-01-16T09:09:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3625,8 +3486,8 @@
       "manufacturer": "Canon/Toshiba",
       "model": "Aplio i 600",
       "serial_number": "C-2019-00140",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-06-30T09:17:54.272Z",
       "modified": "2026-01-16T08:10:54.272Z",
@@ -3635,7 +3496,6 @@
       "app_sw_version": "v2.5.3",
       "last_scanned": "2026-01-13T19:17:54.272Z",
       "last_pinged": "2026-01-16T08:10:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3647,12 +3507,12 @@
       "hostname": "med-dev-00141.hospital.local",
       "ip_address": "192.168.187.140",
       "mac_address": "0e:c7:74:15:9b:4f",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Canon/Toshiba",
       "model": "Aplio i 700",
       "serial_number": "C-2020-00141",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-05-15T09:17:54.272Z",
       "modified": "2026-01-16T07:54:54.272Z",
@@ -3661,7 +3521,6 @@
       "app_sw_version": "v10.6.50",
       "last_scanned": "2026-01-15T02:17:54.272Z",
       "last_pinged": "2026-01-16T07:54:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3677,8 +3536,8 @@
       "manufacturer": "Canon/Toshiba",
       "model": "Aplio i 800",
       "serial_number": "C-2016-00142",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-06-11T09:17:54.272Z",
       "modified": "2026-01-16T09:04:54.272Z",
@@ -3687,7 +3546,6 @@
       "app_sw_version": "v14.7.97",
       "last_scanned": "2026-01-13T10:17:54.272Z",
       "last_pinged": "2026-01-16T09:04:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3703,8 +3561,8 @@
       "manufacturer": "Canon/Toshiba",
       "model": "Aplio i 900",
       "serial_number": "C-2021-00143",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-03-12T09:17:54.272Z",
       "modified": "2026-01-16T09:00:54.272Z",
@@ -3713,7 +3571,6 @@
       "app_sw_version": "v2.4.26",
       "last_scanned": "2026-01-15T05:17:54.272Z",
       "last_pinged": "2026-01-16T09:00:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3725,12 +3582,12 @@
       "hostname": "med-dev-00144.hospital.local",
       "ip_address": "10.211.58.130",
       "mac_address": "d1:b1:80:80:93:48",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Canon/Toshiba",
       "model": "Aplio a 450",
       "serial_number": "C-2022-00144",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-08-04T09:17:54.272Z",
       "modified": "2026-01-16T08:02:54.272Z",
@@ -3739,7 +3596,6 @@
       "app_sw_version": "v12.7.95",
       "last_scanned": "2026-01-16T08:17:54.272Z",
       "last_pinged": "2026-01-16T08:02:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3751,12 +3607,12 @@
       "hostname": "med-dev-00145.hospital.local",
       "ip_address": "10.110.142.219",
       "mac_address": "85:0b:7b:69:44:82",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Canon/Toshiba",
       "model": "Aplio a 550",
       "serial_number": "C-2020-00145",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-01-27T09:17:54.272Z",
       "modified": "2026-01-16T09:02:54.272Z",
@@ -3765,7 +3621,6 @@
       "app_sw_version": "v12.7.45",
       "last_scanned": "2026-01-15T02:17:54.272Z",
       "last_pinged": "2026-01-16T09:02:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3777,12 +3632,12 @@
       "hostname": "med-dev-00146.hospital.local",
       "ip_address": "10.193.127.97",
       "mac_address": "95:43:13:e7:d6:c7",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Canon/Toshiba",
       "model": "Viamo c100",
       "serial_number": "C-2016-00146",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-08-24T09:17:54.272Z",
       "modified": "2026-01-16T08:58:54.272Z",
@@ -3791,7 +3646,6 @@
       "app_sw_version": "v14.3.49",
       "last_scanned": "2026-01-15T08:17:54.272Z",
       "last_pinged": "2026-01-16T08:58:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3807,8 +3661,8 @@
       "manufacturer": "Samsung",
       "model": "HS30",
       "serial_number": "S-2017-00147",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-05-12T09:17:54.272Z",
       "modified": "2026-01-16T08:05:54.272Z",
@@ -3817,7 +3671,6 @@
       "app_sw_version": "v10.7.3",
       "last_scanned": "2026-01-15T14:17:54.272Z",
       "last_pinged": "2026-01-16T08:05:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3833,8 +3686,8 @@
       "manufacturer": "Samsung",
       "model": "HS40",
       "serial_number": "S-2018-00148",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-01-21T09:17:54.272Z",
       "modified": "2026-01-16T07:49:54.272Z",
@@ -3843,7 +3696,6 @@
       "app_sw_version": "v13.0.79",
       "last_scanned": "2026-01-15T02:17:54.272Z",
       "last_pinged": "2026-01-16T07:49:54.272Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3859,8 +3711,8 @@
       "manufacturer": "Samsung",
       "model": "HS50",
       "serial_number": "S-2019-00149",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-03-26T09:17:54.273Z",
       "modified": "2026-01-16T09:12:54.273Z",
@@ -3869,7 +3721,6 @@
       "app_sw_version": "v6.4.69",
       "last_scanned": "2026-01-16T02:17:54.273Z",
       "last_pinged": "2026-01-16T09:12:54.273Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3881,12 +3732,12 @@
       "hostname": "med-dev-00150.hospital.local",
       "ip_address": "172.22.39.153",
       "mac_address": "d3:3d:17:4e:c5:fc",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Samsung",
       "model": "HS60",
       "serial_number": "S-2015-00150",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-01-27T09:17:54.273Z",
       "modified": "2026-01-16T08:15:54.273Z",
@@ -3895,7 +3746,6 @@
       "app_sw_version": "v6.1.77",
       "last_scanned": "2026-01-14T19:17:54.273Z",
       "last_pinged": "2026-01-16T08:15:54.273Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3911,8 +3761,8 @@
       "manufacturer": "Samsung",
       "model": "HS70",
       "serial_number": "S-2015-00151",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-03-12T09:17:54.273Z",
       "modified": "2026-01-16T07:57:54.273Z",
@@ -3921,7 +3771,6 @@
       "app_sw_version": "v12.1.3",
       "last_scanned": "2026-01-16T06:17:54.273Z",
       "last_pinged": "2026-01-16T07:57:54.273Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3937,8 +3786,8 @@
       "manufacturer": "Samsung",
       "model": "Hera I10",
       "serial_number": "S-2021-00152",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-09-11T09:17:54.273Z",
       "modified": "2026-01-16T07:24:54.273Z",
@@ -3947,7 +3796,6 @@
       "app_sw_version": "v9.2.23",
       "last_scanned": "2026-01-13T20:17:54.273Z",
       "last_pinged": "2026-01-16T07:24:54.273Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3963,8 +3811,8 @@
       "manufacturer": "Samsung",
       "model": "Hera W9",
       "serial_number": "S-2017-00153",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-07-20T09:17:54.274Z",
       "modified": "2026-01-16T08:25:54.274Z",
@@ -3973,7 +3821,6 @@
       "app_sw_version": "v15.2.27",
       "last_scanned": "2026-01-14T17:17:54.274Z",
       "last_pinged": "2026-01-16T08:25:54.274Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -3985,12 +3832,12 @@
       "hostname": "med-dev-00154.hospital.local",
       "ip_address": "192.168.135.224",
       "mac_address": "85:84:2c:95:19:fa",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Samsung",
       "model": "Hera W10",
       "serial_number": "S-2016-00154",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-09-12T09:17:54.274Z",
       "modified": "2026-01-16T07:22:54.274Z",
@@ -3999,7 +3846,6 @@
       "app_sw_version": "v15.1.64",
       "last_scanned": "2026-01-13T17:17:54.274Z",
       "last_pinged": "2026-01-16T07:22:54.274Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -4015,8 +3861,8 @@
       "manufacturer": "Samsung",
       "model": "WS80A Elite",
       "serial_number": "S-2019-00155",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-09-06T09:17:54.274Z",
       "modified": "2026-01-16T08:36:54.274Z",
@@ -4025,7 +3871,6 @@
       "app_sw_version": "v14.8.79",
       "last_scanned": "2026-01-13T20:17:54.274Z",
       "last_pinged": "2026-01-16T08:36:54.274Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -4041,8 +3886,8 @@
       "manufacturer": "Samsung",
       "model": "RS85",
       "serial_number": "S-2017-00156",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-06-23T09:17:54.274Z",
       "modified": "2026-01-16T08:46:54.274Z",
@@ -4051,7 +3896,6 @@
       "app_sw_version": "v5.3.24",
       "last_scanned": "2026-01-16T04:17:54.274Z",
       "last_pinged": "2026-01-16T08:46:54.274Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -4067,8 +3911,8 @@
       "manufacturer": "Samsung",
       "model": "RS80",
       "serial_number": "S-2022-00157",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-02-13T09:17:54.274Z",
       "modified": "2026-01-16T07:21:54.274Z",
@@ -4077,7 +3921,6 @@
       "app_sw_version": "v9.8.47",
       "last_scanned": "2026-01-16T01:17:54.274Z",
       "last_pinged": "2026-01-16T07:21:54.274Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -4093,8 +3936,8 @@
       "manufacturer": "Samsung",
       "model": "HM70A",
       "serial_number": "S-2015-00158",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-02-21T09:17:54.275Z",
       "modified": "2026-01-16T07:51:54.275Z",
@@ -4103,7 +3946,6 @@
       "app_sw_version": "v3.9.93",
       "last_scanned": "2026-01-16T08:17:54.275Z",
       "last_pinged": "2026-01-16T07:51:54.275Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -4119,8 +3961,8 @@
       "manufacturer": "Samsung",
       "model": "V8",
       "serial_number": "S-2018-00159",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-02-10T09:17:54.275Z",
       "modified": "2026-01-16T08:28:54.275Z",
@@ -4129,7 +3971,6 @@
       "app_sw_version": "v12.9.49",
       "last_scanned": "2026-01-13T16:17:54.275Z",
       "last_pinged": "2026-01-16T08:28:54.275Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -4145,8 +3986,8 @@
       "manufacturer": "Samsung",
       "model": "V7",
       "serial_number": "S-2021-00160",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-03-05T09:17:54.275Z",
       "modified": "2026-01-16T07:31:54.275Z",
@@ -4155,7 +3996,6 @@
       "app_sw_version": "v15.5.73",
       "last_scanned": "2026-01-16T03:17:54.275Z",
       "last_pinged": "2026-01-16T07:31:54.275Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -4171,8 +4011,8 @@
       "manufacturer": "GE Healthcare",
       "model": "AMX 4 Plus",
       "serial_number": "GH-2021-00161",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2025-01-19T09:17:54.275Z",
       "modified": "2026-01-16T08:45:54.275Z",
@@ -4181,7 +4021,6 @@
       "app_sw_version": "v2.5.71",
       "last_scanned": "2026-01-15T11:17:54.275Z",
       "last_pinged": "2026-01-16T08:45:54.275Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -4197,8 +4036,8 @@
       "manufacturer": "GE Healthcare",
       "model": "AMX 4",
       "serial_number": "GH-2022-00162",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2025-02-19T09:17:54.275Z",
       "modified": "2026-01-16T07:38:54.275Z",
@@ -4207,7 +4046,6 @@
       "app_sw_version": "v10.3.24",
       "last_scanned": "2026-01-16T07:17:54.275Z",
       "last_pinged": "2026-01-16T07:38:54.275Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -4223,8 +4061,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Mobilett Plus",
       "serial_number": "SH-2020-00163",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2025-05-21T09:17:54.276Z",
       "modified": "2026-01-16T08:19:54.276Z",
@@ -4233,7 +4071,6 @@
       "app_sw_version": "v13.8.28",
       "last_scanned": "2026-01-16T02:17:54.276Z",
       "last_pinged": "2026-01-16T08:19:54.276Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -4249,8 +4086,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "AXIOM Iconos R200",
       "serial_number": "SH-2021-00164",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2025-07-02T09:17:54.276Z",
       "modified": "2026-01-16T07:43:54.276Z",
@@ -4259,7 +4096,6 @@
       "app_sw_version": "v6.5.61",
       "last_scanned": "2026-01-15T23:17:54.276Z",
       "last_pinged": "2026-01-16T07:43:54.276Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -4275,8 +4111,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Mobilett XP",
       "serial_number": "SH-2017-00165",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2025-04-12T09:17:54.276Z",
       "modified": "2026-01-16T08:32:54.276Z",
@@ -4285,7 +4121,6 @@
       "app_sw_version": "v13.1.69",
       "last_scanned": "2026-01-15T22:17:54.276Z",
       "last_pinged": "2026-01-16T08:32:54.276Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"2762\"]",
       "external_keys": null
     }
   },
@@ -4301,8 +4136,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Multix Top",
       "serial_number": "SH-2023-00166",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2024-05-09T09:17:54.276Z",
       "modified": "2026-01-16T07:17:54.276Z",
@@ -4311,7 +4146,6 @@
       "app_sw_version": "v7.5.45",
       "last_scanned": "2026-01-15T23:17:54.276Z",
       "last_pinged": "2026-01-16T07:17:54.276Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -4327,8 +4161,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "AXIOM Luminos TF",
       "serial_number": "SH-2022-00167",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2024-04-22T09:17:54.276Z",
       "modified": "2026-01-16T07:51:54.276Z",
@@ -4337,7 +4171,6 @@
       "app_sw_version": "v3.2.17",
       "last_scanned": "2026-01-14T13:17:54.276Z",
       "last_pinged": "2026-01-16T07:51:54.276Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -4349,12 +4182,12 @@
       "hostname": "med-dev-00168.hospital.local",
       "ip_address": "10.44.131.71",
       "mac_address": "ce:b1:ef:16:39:a4",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Philips",
       "model": "Bucky Diagnost",
       "serial_number": "P-2015-00168",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2025-04-14T09:17:54.276Z",
       "modified": "2026-01-16T07:24:54.276Z",
@@ -4363,7 +4196,6 @@
       "app_sw_version": "v5.7.28",
       "last_scanned": "2026-01-15T13:17:54.276Z",
       "last_pinged": "2026-01-16T07:24:54.276Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -4379,8 +4211,8 @@
       "manufacturer": "Philips",
       "model": "Bucky Diagnost TH",
       "serial_number": "P-2017-00169",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2024-02-08T09:17:54.276Z",
       "modified": "2026-01-16T09:07:54.276Z",
@@ -4389,7 +4221,6 @@
       "app_sw_version": "v5.7.66",
       "last_scanned": "2026-01-13T13:17:54.276Z",
       "last_pinged": "2026-01-16T09:07:54.276Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -4401,12 +4232,12 @@
       "hostname": "med-dev-00170.hospital.local",
       "ip_address": "172.18.186.155",
       "mac_address": "cf:fc:0e:94:a5:27",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Philips",
       "model": "Practix 300",
       "serial_number": "P-2016-00170",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2024-09-30T09:17:54.276Z",
       "modified": "2026-01-16T08:45:54.276Z",
@@ -4415,7 +4246,6 @@
       "app_sw_version": "v1.1.96",
       "last_scanned": "2026-01-13T18:17:54.276Z",
       "last_pinged": "2026-01-16T08:45:54.276Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"2762\"]",
       "external_keys": null
     }
   },
@@ -4431,8 +4261,8 @@
       "manufacturer": "Philips",
       "model": "MobileDiagnost wDR",
       "serial_number": "P-2023-00171",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2024-04-04T09:17:54.276Z",
       "modified": "2026-01-16T07:52:54.276Z",
@@ -4441,7 +4271,6 @@
       "app_sw_version": "v10.5.18",
       "last_scanned": "2026-01-14T22:17:54.276Z",
       "last_pinged": "2026-01-16T07:52:54.276Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -4457,8 +4286,8 @@
       "manufacturer": "Shimadzu",
       "model": "MobileArt Evolution",
       "serial_number": "S-2021-00172",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2024-11-30T09:17:54.276Z",
       "modified": "2026-01-16T08:36:54.276Z",
@@ -4467,7 +4296,6 @@
       "app_sw_version": "v1.9.34",
       "last_scanned": "2026-01-14T05:17:54.276Z",
       "last_pinged": "2026-01-16T08:36:54.276Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -4479,12 +4307,12 @@
       "hostname": "med-dev-00173.hospital.local",
       "ip_address": "10.39.32.40",
       "mac_address": "53:f0:17:08:55:e7",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Shimadzu",
       "model": "MobileArt Plus",
       "serial_number": "S-2016-00173",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2024-07-18T09:17:54.276Z",
       "modified": "2026-01-16T07:37:54.276Z",
@@ -4493,7 +4321,6 @@
       "app_sw_version": "v11.3.35",
       "last_scanned": "2026-01-13T16:17:54.276Z",
       "last_pinged": "2026-01-16T07:37:54.276Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"2762\"]",
       "external_keys": null
     }
   },
@@ -4509,8 +4336,8 @@
       "manufacturer": "Shimadzu",
       "model": "Radspeed Pro",
       "serial_number": "S-2020-00174",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2025-04-30T09:17:54.276Z",
       "modified": "2026-01-16T08:40:54.276Z",
@@ -4519,7 +4346,6 @@
       "app_sw_version": "v10.9.63",
       "last_scanned": "2026-01-15T03:17:54.276Z",
       "last_pinged": "2026-01-16T08:40:54.276Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -4535,8 +4361,8 @@
       "manufacturer": "Fujifilm",
       "model": "FCR GO",
       "serial_number": "F-2019-00175",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2024-06-18T09:17:54.276Z",
       "modified": "2026-01-16T08:40:54.276Z",
@@ -4545,7 +4371,6 @@
       "app_sw_version": "v7.1.75",
       "last_scanned": "2026-01-14T07:17:54.276Z",
       "last_pinged": "2026-01-16T08:40:54.276Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -4561,8 +4386,8 @@
       "manufacturer": "Del Medical",
       "model": "Universal",
       "serial_number": "DM-2016-00176",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2024-05-14T09:17:54.276Z",
       "modified": "2026-01-16T08:31:54.276Z",
@@ -4571,7 +4396,6 @@
       "app_sw_version": "v2.8.82",
       "last_scanned": "2026-01-14T07:17:54.276Z",
       "last_pinged": "2026-01-16T08:31:54.276Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"2762\"]",
       "external_keys": null
     }
   },
@@ -4587,8 +4411,8 @@
       "manufacturer": "Quantum Medical Imaging",
       "model": "Verti-Q",
       "serial_number": "QM-2020-00177",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2024-07-22T09:17:54.276Z",
       "modified": "2026-01-16T08:38:54.276Z",
@@ -4597,7 +4421,6 @@
       "app_sw_version": "v3.5.2",
       "last_scanned": "2026-01-15T02:17:54.276Z",
       "last_pinged": "2026-01-16T08:38:54.276Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -4613,8 +4436,8 @@
       "manufacturer": "Agfa",
       "model": "DX-D 100",
       "serial_number": "A-2023-00178",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Digital X-ray",
       "created": "2025-01-17T09:17:54.276Z",
       "modified": "2026-01-16T07:27:54.276Z",
@@ -4623,7 +4446,6 @@
       "app_sw_version": "v14.8.18",
       "last_scanned": "2026-01-15T13:17:54.276Z",
       "last_pinged": "2026-01-16T07:27:54.276Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -4639,8 +4461,8 @@
       "manufacturer": "Philips",
       "model": "IntelliVue MP5",
       "serial_number": "P-2020-00179",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Patient Monitor",
       "created": "2024-11-08T09:17:54.276Z",
       "modified": "2026-01-16T07:18:54.276Z",
@@ -4649,7 +4471,6 @@
       "app_sw_version": "v5.0.42",
       "last_scanned": "2026-01-16T08:17:54.276Z",
       "last_pinged": "2026-01-16T07:18:54.276Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2575\", \"8000\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -4665,8 +4486,8 @@
       "manufacturer": "Philips",
       "model": "IntelliVue MP5T",
       "serial_number": "P-2018-00180",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Patient Monitor",
       "created": "2024-07-20T09:17:54.276Z",
       "modified": "2026-01-16T07:17:54.276Z",
@@ -4675,7 +4496,6 @@
       "app_sw_version": "v14.6.26",
       "last_scanned": "2026-01-16T03:17:54.276Z",
       "last_pinged": "2026-01-16T07:17:54.276Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2575\", \"8000\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -4687,12 +4507,12 @@
       "hostname": "med-dev-00181.hospital.local",
       "ip_address": "192.168.224.247",
       "mac_address": "0e:8e:23:8f:a7:b9",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Philips",
       "model": "IntelliVue MP5SC",
       "serial_number": "P-2022-00181",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Patient Monitor",
       "created": "2025-04-18T09:17:54.276Z",
       "modified": "2026-01-16T08:48:54.276Z",
@@ -4701,7 +4521,6 @@
       "app_sw_version": "v5.4.65",
       "last_scanned": "2026-01-13T10:17:54.276Z",
       "last_pinged": "2026-01-16T08:48:54.276Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2575\", \"8000\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -4717,8 +4536,8 @@
       "manufacturer": "GE Healthcare",
       "model": "CARESCAPE Monitor B650",
       "serial_number": "GH-2017-00182",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Patient Monitor",
       "created": "2025-05-31T09:17:54.276Z",
       "modified": "2026-01-16T07:34:54.276Z",
@@ -4727,7 +4546,6 @@
       "app_sw_version": "v1.1.92",
       "last_scanned": "2026-01-13T10:17:54.276Z",
       "last_pinged": "2026-01-16T07:34:54.276Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2575\", \"8000\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -4743,8 +4561,8 @@
       "manufacturer": "BD / Alaris",
       "model": "Alaris 8015 PC Unit",
       "serial_number": "B/-2016-00183",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2024-08-15T09:17:54.276Z",
       "modified": "2026-01-16T09:07:54.276Z",
@@ -4753,7 +4571,6 @@
       "app_sw_version": "v7.5.58",
       "last_scanned": "2026-01-13T18:17:54.276Z",
       "last_pinged": "2026-01-16T09:07:54.276Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -4769,8 +4586,8 @@
       "manufacturer": "BD / Alaris",
       "model": "Alaris 8100 Infusion Pump Module",
       "serial_number": "B/-2016-00184",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2024-01-27T09:17:54.276Z",
       "modified": "2026-01-16T08:30:54.276Z",
@@ -4779,7 +4596,6 @@
       "app_sw_version": "v5.7.88",
       "last_scanned": "2026-01-16T05:17:54.276Z",
       "last_pinged": "2026-01-16T08:30:54.276Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -4795,8 +4611,8 @@
       "manufacturer": "BD / Alaris",
       "model": "Alaris 8110 Syringe Pump",
       "serial_number": "B/-2019-00185",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2024-11-16T09:17:54.276Z",
       "modified": "2026-01-16T08:58:54.276Z",
@@ -4805,7 +4621,6 @@
       "app_sw_version": "v8.6.73",
       "last_scanned": "2026-01-15T04:17:54.276Z",
       "last_pinged": "2026-01-16T08:58:54.276Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -4821,8 +4636,8 @@
       "manufacturer": "BD / Alaris",
       "model": "Alaris 8120 PCA Pump",
       "serial_number": "B/-2018-00186",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2025-06-27T09:17:54.276Z",
       "modified": "2026-01-16T07:45:54.276Z",
@@ -4831,7 +4646,6 @@
       "app_sw_version": "v1.6.23",
       "last_scanned": "2026-01-13T13:17:54.276Z",
       "last_pinged": "2026-01-16T07:45:54.276Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -4847,8 +4661,8 @@
       "manufacturer": "BD / Alaris",
       "model": "Alaris 8300 ETCO\u2082 Module",
       "serial_number": "B/-2017-00187",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2024-08-07T09:17:54.276Z",
       "modified": "2026-01-16T09:06:54.276Z",
@@ -4857,7 +4671,6 @@
       "app_sw_version": "v8.3.41",
       "last_scanned": "2026-01-15T05:17:54.276Z",
       "last_pinged": "2026-01-16T09:06:54.276Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -4869,12 +4682,12 @@
       "hostname": "med-dev-00188.hospital.local",
       "ip_address": "10.24.94.81",
       "mac_address": "b7:a2:7a:5d:4e:c6",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "BD / Alaris",
       "model": "Alaris 7230 Dual-Channel IV Pump",
       "serial_number": "B/-2018-00188",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2025-03-15T09:17:54.277Z",
       "modified": "2026-01-16T08:00:54.277Z",
@@ -4883,7 +4696,6 @@
       "app_sw_version": "v15.2.19",
       "last_scanned": "2026-01-14T10:17:54.277Z",
       "last_pinged": "2026-01-16T08:00:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -4899,8 +4711,8 @@
       "manufacturer": "B. Braun",
       "model": "Perfusor Space Infusion Pump System",
       "serial_number": "BB-2016-00189",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2024-05-26T09:17:54.277Z",
       "modified": "2026-01-16T08:42:54.277Z",
@@ -4909,7 +4721,6 @@
       "app_sw_version": "v4.4.97",
       "last_scanned": "2026-01-13T11:17:54.277Z",
       "last_pinged": "2026-01-16T08:42:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -4925,8 +4736,8 @@
       "manufacturer": "Baxter",
       "model": "Spectrum IQ Infusion System",
       "serial_number": "B-2017-00190",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2024-10-12T09:17:54.277Z",
       "modified": "2026-01-16T08:11:54.277Z",
@@ -4935,7 +4746,6 @@
       "app_sw_version": "v8.8.37",
       "last_scanned": "2026-01-15T18:17:54.277Z",
       "last_pinged": "2026-01-16T08:11:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -4951,8 +4761,8 @@
       "manufacturer": "Philips Respironics",
       "model": "V60 Ventilator",
       "serial_number": "PR-2023-00191",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2025-02-18T09:17:54.277Z",
       "modified": "2026-01-16T08:46:54.277Z",
@@ -4961,7 +4771,6 @@
       "app_sw_version": "v15.4.66",
       "last_scanned": "2026-01-15T21:17:54.277Z",
       "last_pinged": "2026-01-16T08:46:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -4977,8 +4786,8 @@
       "manufacturer": "GE Healthcare",
       "model": "CARESCAPE R860 Ventilator",
       "serial_number": "GH-2021-00192",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2024-08-11T09:17:54.277Z",
       "modified": "2026-01-16T09:02:54.277Z",
@@ -4987,7 +4796,6 @@
       "app_sw_version": "v1.3.6",
       "last_scanned": "2026-01-15T01:17:54.277Z",
       "last_pinged": "2026-01-16T09:02:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -5003,8 +4811,8 @@
       "manufacturer": "Dr\u00e4ger",
       "model": "Evita Infinity V500 Ventilator",
       "serial_number": "D-2015-00193",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2024-06-15T09:17:54.277Z",
       "modified": "2026-01-16T08:31:54.277Z",
@@ -5013,7 +4821,6 @@
       "app_sw_version": "v5.5.81",
       "last_scanned": "2026-01-14T02:17:54.277Z",
       "last_pinged": "2026-01-16T08:31:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -5029,8 +4836,8 @@
       "manufacturer": "Hamilton Medical",
       "model": "HAMILTON-C6",
       "serial_number": "HM-2019-00194",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2024-08-18T09:17:54.277Z",
       "modified": "2026-01-16T09:07:54.277Z",
@@ -5039,7 +4846,6 @@
       "app_sw_version": "v5.3.47",
       "last_scanned": "2026-01-15T11:17:54.277Z",
       "last_pinged": "2026-01-16T09:07:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -5055,8 +4861,8 @@
       "manufacturer": "Hamilton Medical",
       "model": "HAMILTON-S1",
       "serial_number": "HM-2022-00195",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2024-11-26T09:17:54.277Z",
       "modified": "2026-01-16T08:16:54.277Z",
@@ -5065,7 +4871,6 @@
       "app_sw_version": "v8.6.89",
       "last_scanned": "2026-01-15T03:17:54.277Z",
       "last_pinged": "2026-01-16T08:16:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -5077,12 +4882,12 @@
       "hostname": "med-dev-00196.hospital.local",
       "ip_address": "172.22.251.102",
       "mac_address": "c2:e9:c3:a6:e7:10",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Hamilton Medical",
       "model": "HAMILTON-G5",
       "serial_number": "HM-2016-00196",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2024-03-06T09:17:54.277Z",
       "modified": "2026-01-16T08:09:54.277Z",
@@ -5091,7 +4896,6 @@
       "app_sw_version": "v3.7.55",
       "last_scanned": "2026-01-14T13:17:54.277Z",
       "last_pinged": "2026-01-16T08:09:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -5107,8 +4911,8 @@
       "manufacturer": "Hamilton Medical",
       "model": "HAMILTON-C3",
       "serial_number": "HM-2022-00197",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2025-02-21T09:17:54.277Z",
       "modified": "2026-01-16T09:06:54.277Z",
@@ -5117,7 +4921,6 @@
       "app_sw_version": "v4.0.92",
       "last_scanned": "2026-01-16T01:17:54.277Z",
       "last_pinged": "2026-01-16T09:06:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -5133,8 +4936,8 @@
       "manufacturer": "Hamilton Medical",
       "model": "HAMILTON-C1",
       "serial_number": "HM-2022-00198",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2024-07-30T09:17:54.277Z",
       "modified": "2026-01-16T07:58:54.277Z",
@@ -5143,7 +4946,6 @@
       "app_sw_version": "v2.2.47",
       "last_scanned": "2026-01-14T15:17:54.277Z",
       "last_pinged": "2026-01-16T07:58:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -5159,8 +4961,8 @@
       "manufacturer": "Hamilton Medical",
       "model": "HAMILTON-C1 neo",
       "serial_number": "HM-2023-00199",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2025-06-06T09:17:54.277Z",
       "modified": "2026-01-16T07:57:54.277Z",
@@ -5169,7 +4971,6 @@
       "app_sw_version": "v9.8.68",
       "last_scanned": "2026-01-13T12:17:54.277Z",
       "last_pinged": "2026-01-16T07:57:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -5185,8 +4986,8 @@
       "manufacturer": "Hamilton Medical",
       "model": "HAMILTON-T1",
       "serial_number": "HM-2023-00200",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2024-01-31T09:17:54.277Z",
       "modified": "2026-01-16T08:49:54.277Z",
@@ -5195,7 +4996,6 @@
       "app_sw_version": "v1.7.93",
       "last_scanned": "2026-01-13T20:17:54.277Z",
       "last_pinged": "2026-01-16T08:49:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -5211,8 +5011,8 @@
       "manufacturer": "Hamilton Medical",
       "model": "HAMILTON-MR1",
       "serial_number": "HM-2020-00201",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2024-02-24T09:17:54.277Z",
       "modified": "2026-01-16T09:07:54.277Z",
@@ -5221,7 +5021,6 @@
       "app_sw_version": "v10.0.95",
       "last_scanned": "2026-01-14T16:17:54.277Z",
       "last_pinged": "2026-01-16T09:07:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -5237,8 +5036,8 @@
       "manufacturer": "Dr\u00e4ger",
       "model": "Perseus A500",
       "serial_number": "D-2015-00202",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Anesthesia Machine",
       "created": "2024-09-07T09:17:54.277Z",
       "modified": "2026-01-16T07:26:54.277Z",
@@ -5247,7 +5046,6 @@
       "app_sw_version": "v10.7.81",
       "last_scanned": "2026-01-13T22:17:54.277Z",
       "last_pinged": "2026-01-16T07:26:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5259,12 +5057,12 @@
       "hostname": "med-dev-00203.hospital.local",
       "ip_address": "10.117.84.154",
       "mac_address": "d9:b4:16:bd:39:a4",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Dr\u00e4ger",
       "model": "Apollo",
       "serial_number": "D-2018-00203",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Anesthesia Machine",
       "created": "2025-04-02T09:17:54.277Z",
       "modified": "2026-01-16T08:57:54.277Z",
@@ -5273,7 +5071,6 @@
       "app_sw_version": "v5.9.97",
       "last_scanned": "2026-01-15T13:17:54.277Z",
       "last_pinged": "2026-01-16T08:57:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5289,8 +5086,8 @@
       "manufacturer": "Dr\u00e4ger",
       "model": "Fabius GS Premium",
       "serial_number": "D-2015-00204",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Anesthesia Machine",
       "created": "2024-09-19T09:17:54.277Z",
       "modified": "2026-01-16T08:56:54.277Z",
@@ -5299,7 +5096,6 @@
       "app_sw_version": "v12.7.74",
       "last_scanned": "2026-01-14T13:17:54.277Z",
       "last_pinged": "2026-01-16T08:56:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5315,8 +5111,8 @@
       "manufacturer": "Dr\u00e4ger",
       "model": "Fabius Tiro",
       "serial_number": "D-2020-00205",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Anesthesia Machine",
       "created": "2025-06-26T09:17:54.277Z",
       "modified": "2026-01-16T07:47:54.277Z",
@@ -5325,7 +5121,6 @@
       "app_sw_version": "v10.9.44",
       "last_scanned": "2026-01-15T10:17:54.277Z",
       "last_pinged": "2026-01-16T07:47:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5341,8 +5136,8 @@
       "manufacturer": "Dr\u00e4ger",
       "model": "Narkomed 2B",
       "serial_number": "D-2018-00206",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Anesthesia Machine",
       "created": "2025-05-19T09:17:54.277Z",
       "modified": "2026-01-16T07:19:54.277Z",
@@ -5351,7 +5146,6 @@
       "app_sw_version": "v7.6.23",
       "last_scanned": "2026-01-16T00:17:54.277Z",
       "last_pinged": "2026-01-16T07:19:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5363,12 +5157,12 @@
       "hostname": "med-dev-00207.hospital.local",
       "ip_address": "10.123.143.48",
       "mac_address": "dd:27:c1:35:3d:ce",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "Avance CS2",
       "serial_number": "GH-2019-00207",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Anesthesia Machine",
       "created": "2024-02-19T09:17:54.277Z",
       "modified": "2026-01-16T08:54:54.277Z",
@@ -5377,7 +5171,6 @@
       "app_sw_version": "v4.5.11",
       "last_scanned": "2026-01-15T07:17:54.277Z",
       "last_pinged": "2026-01-16T08:54:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5393,8 +5186,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Aisys CS2",
       "serial_number": "GH-2023-00208",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Anesthesia Machine",
       "created": "2024-11-30T09:17:54.277Z",
       "modified": "2026-01-16T09:11:54.277Z",
@@ -5403,7 +5196,6 @@
       "app_sw_version": "v11.3.26",
       "last_scanned": "2026-01-15T12:17:54.277Z",
       "last_pinged": "2026-01-16T09:11:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5419,8 +5211,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Carestation 650",
       "serial_number": "GH-2021-00209",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Anesthesia Machine",
       "created": "2025-02-23T09:17:54.277Z",
       "modified": "2026-01-16T09:01:54.277Z",
@@ -5429,7 +5221,6 @@
       "app_sw_version": "v5.9.59",
       "last_scanned": "2026-01-15T16:17:54.277Z",
       "last_pinged": "2026-01-16T09:01:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5441,12 +5232,12 @@
       "hostname": "med-dev-00210.hospital.local",
       "ip_address": "10.107.246.190",
       "mac_address": "1d:67:df:87:37:3a",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "Aespire View",
       "serial_number": "GH-2022-00210",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Anesthesia Machine",
       "created": "2024-03-28T09:17:54.277Z",
       "modified": "2026-01-16T08:23:54.277Z",
@@ -5455,7 +5246,6 @@
       "app_sw_version": "v8.9.93",
       "last_scanned": "2026-01-16T01:17:54.277Z",
       "last_pinged": "2026-01-16T08:23:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5471,8 +5261,8 @@
       "manufacturer": "Fresenius Medical Care",
       "model": "6008 CAREsystem",
       "serial_number": "FM-2016-00211",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Dialysis Machine",
       "created": "2025-01-07T09:17:54.277Z",
       "modified": "2026-01-16T08:28:54.277Z",
@@ -5481,7 +5271,6 @@
       "app_sw_version": "v3.5.80",
       "last_scanned": "2026-01-14T05:17:54.277Z",
       "last_pinged": "2026-01-16T08:28:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5497,8 +5286,8 @@
       "manufacturer": "Fresenius Medical Care",
       "model": "5008S CorDiax",
       "serial_number": "FM-2017-00212",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Dialysis Machine",
       "created": "2025-07-14T09:17:54.277Z",
       "modified": "2026-01-16T08:08:54.277Z",
@@ -5507,7 +5296,6 @@
       "app_sw_version": "v2.0.22",
       "last_scanned": "2026-01-14T17:17:54.277Z",
       "last_pinged": "2026-01-16T08:08:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5523,8 +5311,8 @@
       "manufacturer": "Fresenius Medical Care",
       "model": "4008S classix",
       "serial_number": "FM-2016-00213",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Dialysis Machine",
       "created": "2025-03-01T09:17:54.277Z",
       "modified": "2026-01-16T08:10:54.277Z",
@@ -5533,7 +5321,6 @@
       "app_sw_version": "v13.2.7",
       "last_scanned": "2026-01-15T13:17:54.277Z",
       "last_pinged": "2026-01-16T08:10:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5549,8 +5336,8 @@
       "manufacturer": "Medtronic (Valleylab)",
       "model": "ForceTriad Energy Platform",
       "serial_number": "M(-2016-00214",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Electrosurgical Unit",
       "created": "2024-11-03T09:17:54.277Z",
       "modified": "2026-01-16T07:33:54.277Z",
@@ -5559,7 +5346,6 @@
       "app_sw_version": "v5.6.53",
       "last_scanned": "2026-01-15T18:17:54.277Z",
       "last_pinged": "2026-01-16T07:33:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -5575,8 +5361,8 @@
       "manufacturer": "Medtronic (Valleylab)",
       "model": "FT10 Energy Platform",
       "serial_number": "M(-2021-00215",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Electrosurgical Unit",
       "created": "2025-01-01T09:17:54.277Z",
       "modified": "2026-01-16T07:18:54.277Z",
@@ -5585,7 +5371,6 @@
       "app_sw_version": "v1.7.32",
       "last_scanned": "2026-01-14T23:17:54.277Z",
       "last_pinged": "2026-01-16T07:18:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -5601,8 +5386,8 @@
       "manufacturer": "ZOLL Medical",
       "model": "X Series monitor/defibrillator",
       "serial_number": "ZM-2022-00216",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-11-27T09:17:54.277Z",
       "modified": "2026-01-16T08:13:54.277Z",
@@ -5611,7 +5396,6 @@
       "app_sw_version": "v15.4.91",
       "last_scanned": "2026-01-16T02:17:54.277Z",
       "last_pinged": "2026-01-16T08:13:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5627,8 +5411,8 @@
       "manufacturer": "ZOLL Medical",
       "model": "R Series ALS monitor/defibrillator",
       "serial_number": "ZM-2022-00217",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2025-04-13T09:17:54.277Z",
       "modified": "2026-01-16T07:30:54.277Z",
@@ -5637,7 +5421,6 @@
       "app_sw_version": "v3.7.49",
       "last_scanned": "2026-01-13T19:17:54.277Z",
       "last_pinged": "2026-01-16T07:30:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5653,8 +5436,8 @@
       "manufacturer": "ZOLL Medical",
       "model": "AED Pro",
       "serial_number": "ZM-2023-00218",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-08-23T09:17:54.277Z",
       "modified": "2026-01-16T08:57:54.277Z",
@@ -5663,7 +5446,6 @@
       "app_sw_version": "v5.1.70",
       "last_scanned": "2026-01-13T13:17:54.277Z",
       "last_pinged": "2026-01-16T08:57:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5675,12 +5457,12 @@
       "hostname": "med-dev-00219.hospital.local",
       "ip_address": "172.19.194.1",
       "mac_address": "6b:9f:04:62:d6:6f",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "ZOLL Medical",
       "model": "AED Plus",
       "serial_number": "ZM-2015-00219",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-06-02T09:17:54.277Z",
       "modified": "2026-01-16T07:29:54.277Z",
@@ -5689,7 +5471,6 @@
       "app_sw_version": "v9.4.93",
       "last_scanned": "2026-01-16T03:17:54.277Z",
       "last_pinged": "2026-01-16T07:29:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5701,12 +5482,12 @@
       "hostname": "med-dev-00220.hospital.local",
       "ip_address": "192.168.218.65",
       "mac_address": "3c:b6:4f:04:b1:95",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Philips",
       "model": "HeartStart FRx",
       "serial_number": "P-2018-00220",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-06-17T09:17:54.277Z",
       "modified": "2026-01-16T08:49:54.277Z",
@@ -5715,7 +5496,6 @@
       "app_sw_version": "v3.6.4",
       "last_scanned": "2026-01-15T00:17:54.277Z",
       "last_pinged": "2026-01-16T08:49:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5731,8 +5511,8 @@
       "manufacturer": "Philips",
       "model": "HeartStart OnSite",
       "serial_number": "P-2019-00221",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-04-20T09:17:54.277Z",
       "modified": "2026-01-16T07:53:54.277Z",
@@ -5741,7 +5521,6 @@
       "app_sw_version": "v7.4.10",
       "last_scanned": "2026-01-14T15:17:54.277Z",
       "last_pinged": "2026-01-16T07:53:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5757,8 +5536,8 @@
       "manufacturer": "Philips",
       "model": "HeartStart FR3",
       "serial_number": "P-2023-00222",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-01-20T09:17:54.277Z",
       "modified": "2026-01-16T08:08:54.277Z",
@@ -5767,7 +5546,6 @@
       "app_sw_version": "v8.8.52",
       "last_scanned": "2026-01-14T04:17:54.277Z",
       "last_pinged": "2026-01-16T08:08:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5783,8 +5561,8 @@
       "manufacturer": "Cardiac Science",
       "model": "Powerheart G3",
       "serial_number": "CS-2021-00223",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2025-04-15T09:17:54.277Z",
       "modified": "2026-01-16T07:44:54.277Z",
@@ -5793,7 +5571,6 @@
       "app_sw_version": "v9.4.88",
       "last_scanned": "2026-01-16T07:17:54.277Z",
       "last_pinged": "2026-01-16T07:44:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5809,8 +5586,8 @@
       "manufacturer": "Cardiac Science",
       "model": "Powerheart G3 Plus",
       "serial_number": "CS-2019-00224",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2025-02-22T09:17:54.277Z",
       "modified": "2026-01-16T07:43:54.277Z",
@@ -5819,7 +5596,6 @@
       "app_sw_version": "v15.8.85",
       "last_scanned": "2026-01-13T15:17:54.277Z",
       "last_pinged": "2026-01-16T07:43:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5835,8 +5611,8 @@
       "manufacturer": "Cardiac Science",
       "model": "Powerheart G5",
       "serial_number": "CS-2018-00225",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2025-06-23T09:17:54.277Z",
       "modified": "2026-01-16T07:41:54.277Z",
@@ -5845,7 +5621,6 @@
       "app_sw_version": "v6.5.5",
       "last_scanned": "2026-01-15T03:17:54.277Z",
       "last_pinged": "2026-01-16T07:41:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5861,8 +5636,8 @@
       "manufacturer": "Cardiac Science",
       "model": "Powerheart G3 Pro",
       "serial_number": "CS-2015-00226",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-01-22T09:17:54.277Z",
       "modified": "2026-01-16T09:08:54.277Z",
@@ -5871,7 +5646,6 @@
       "app_sw_version": "v10.7.17",
       "last_scanned": "2026-01-15T11:17:54.277Z",
       "last_pinged": "2026-01-16T09:08:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5887,8 +5661,8 @@
       "manufacturer": "Defibtech",
       "model": "Lifeline AED",
       "serial_number": "D-2022-00227",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2025-04-13T09:17:54.277Z",
       "modified": "2026-01-16T07:56:54.277Z",
@@ -5897,7 +5671,6 @@
       "app_sw_version": "v6.6.44",
       "last_scanned": "2026-01-15T16:17:54.277Z",
       "last_pinged": "2026-01-16T07:56:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5913,8 +5686,8 @@
       "manufacturer": "Defibtech",
       "model": "Lifeline ReviveR DDU-100",
       "serial_number": "D-2020-00228",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-02-19T09:17:54.277Z",
       "modified": "2026-01-16T08:26:54.277Z",
@@ -5923,7 +5696,6 @@
       "app_sw_version": "v11.9.93",
       "last_scanned": "2026-01-13T10:17:54.277Z",
       "last_pinged": "2026-01-16T08:26:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5939,8 +5711,8 @@
       "manufacturer": "Defibtech",
       "model": "Lifeline ReviveR DDU-120",
       "serial_number": "D-2022-00229",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2025-01-06T09:17:54.277Z",
       "modified": "2026-01-16T07:52:54.277Z",
@@ -5949,7 +5721,6 @@
       "app_sw_version": "v2.5.42",
       "last_scanned": "2026-01-14T02:17:54.277Z",
       "last_pinged": "2026-01-16T07:52:54.277Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5965,8 +5736,8 @@
       "manufacturer": "Defibtech",
       "model": "Lifeline ReviveR DDU-2300",
       "serial_number": "D-2018-00230",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-10-29T09:17:54.278Z",
       "modified": "2026-01-16T07:19:54.278Z",
@@ -5975,7 +5746,6 @@
       "app_sw_version": "v2.2.98",
       "last_scanned": "2026-01-14T19:17:54.278Z",
       "last_pinged": "2026-01-16T07:19:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -5987,12 +5757,12 @@
       "hostname": "med-dev-00231.hospital.local",
       "ip_address": "172.29.209.252",
       "mac_address": "39:05:8f:2c:98:88",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Defibtech",
       "model": "Lifeline ReviveR DDU-2200",
       "serial_number": "D-2020-00231",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2025-04-07T09:17:54.278Z",
       "modified": "2026-01-16T08:42:54.278Z",
@@ -6001,7 +5771,6 @@
       "app_sw_version": "v6.1.99",
       "last_scanned": "2026-01-13T20:17:54.278Z",
       "last_pinged": "2026-01-16T08:42:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -6017,8 +5786,8 @@
       "manufacturer": "Defibtech",
       "model": "Lifeline ReviveR DDU-2450",
       "serial_number": "D-2019-00232",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-02-22T09:17:54.278Z",
       "modified": "2026-01-16T08:06:54.278Z",
@@ -6027,7 +5796,6 @@
       "app_sw_version": "v9.8.89",
       "last_scanned": "2026-01-14T05:17:54.278Z",
       "last_pinged": "2026-01-16T08:06:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -6039,12 +5807,12 @@
       "hostname": "med-dev-00233.hospital.local",
       "ip_address": "192.168.227.77",
       "mac_address": "2e:e4:fe:02:aa:97",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Avive",
       "model": "Avive Automated External Defibrillator",
       "serial_number": "A-2016-00233",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-12-15T09:17:54.278Z",
       "modified": "2026-01-16T07:32:54.278Z",
@@ -6053,7 +5821,6 @@
       "app_sw_version": "v4.1.61",
       "last_scanned": "2026-01-15T16:17:54.278Z",
       "last_pinged": "2026-01-16T07:32:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -6069,8 +5836,8 @@
       "manufacturer": "Intuitive Surgical",
       "model": "da Vinci Xi surgical system",
       "serial_number": "IS-2016-00234",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2025-01-13T09:17:54.278Z",
       "modified": "2026-01-16T08:11:54.278Z",
@@ -6079,7 +5846,6 @@
       "app_sw_version": "v1.6.98",
       "last_scanned": "2026-01-14T08:17:54.278Z",
       "last_pinged": "2026-01-16T08:11:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -6095,8 +5861,8 @@
       "manufacturer": "Stryker",
       "model": "Mako SmartRobotics - Total Knee",
       "serial_number": "S-2020-00235",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2025-03-11T09:17:54.278Z",
       "modified": "2026-01-16T08:51:54.278Z",
@@ -6105,7 +5871,6 @@
       "app_sw_version": "v5.4.93",
       "last_scanned": "2026-01-15T17:17:54.278Z",
       "last_pinged": "2026-01-16T08:51:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -6121,8 +5886,8 @@
       "manufacturer": "Stryker",
       "model": "Mako SmartRobotics - Total Hip",
       "serial_number": "S-2023-00236",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2025-01-25T09:17:54.278Z",
       "modified": "2026-01-16T08:17:54.278Z",
@@ -6131,7 +5896,6 @@
       "app_sw_version": "v15.0.22",
       "last_scanned": "2026-01-14T17:17:54.278Z",
       "last_pinged": "2026-01-16T08:17:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -6147,8 +5911,8 @@
       "manufacturer": "Stryker",
       "model": "Mako SmartRobotics - Partial Knee",
       "serial_number": "S-2016-00237",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2024-10-16T09:17:54.278Z",
       "modified": "2026-01-16T08:54:54.278Z",
@@ -6157,7 +5921,6 @@
       "app_sw_version": "v2.2.81",
       "last_scanned": "2026-01-15T08:17:54.278Z",
       "last_pinged": "2026-01-16T08:54:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -6173,8 +5936,8 @@
       "manufacturer": "Stryker",
       "model": "Mako SmartRobotics - Spine",
       "serial_number": "S-2019-00238",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2025-07-17T09:17:54.278Z",
       "modified": "2026-01-16T08:56:54.278Z",
@@ -6183,7 +5946,6 @@
       "app_sw_version": "v1.9.55",
       "last_scanned": "2026-01-13T17:17:54.278Z",
       "last_pinged": "2026-01-16T08:56:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -6199,8 +5961,8 @@
       "manufacturer": "Stryker",
       "model": "Mako 4 system",
       "serial_number": "S-2016-00239",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2025-07-19T09:17:54.278Z",
       "modified": "2026-01-16T09:07:54.278Z",
@@ -6209,7 +5971,6 @@
       "app_sw_version": "v10.8.67",
       "last_scanned": "2026-01-14T13:17:54.278Z",
       "last_pinged": "2026-01-16T09:07:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -6225,8 +5986,8 @@
       "manufacturer": "Zimmer Biomet",
       "model": "ROSA Robotic Surgical Assistant - Shoulder",
       "serial_number": "ZB-2015-00240",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2025-02-12T09:17:54.278Z",
       "modified": "2026-01-16T07:49:54.278Z",
@@ -6235,7 +5996,6 @@
       "app_sw_version": "v11.6.84",
       "last_scanned": "2026-01-14T16:17:54.278Z",
       "last_pinged": "2026-01-16T07:49:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -6247,12 +6007,12 @@
       "hostname": "med-dev-00241.hospital.local",
       "ip_address": "10.216.195.41",
       "mac_address": "50:82:a9:cf:1c:d4",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Zimmer Biomet",
       "model": "ROSA Robotic Surgical Assistant - Knee",
       "serial_number": "ZB-2016-00241",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2024-09-30T09:17:54.278Z",
       "modified": "2026-01-16T07:17:54.278Z",
@@ -6261,7 +6021,6 @@
       "app_sw_version": "v2.9.62",
       "last_scanned": "2026-01-13T13:17:54.278Z",
       "last_pinged": "2026-01-16T07:17:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -6273,12 +6032,12 @@
       "hostname": "med-dev-00242.hospital.local",
       "ip_address": "172.22.15.108",
       "mac_address": "ce:65:ec:fd:d9:fa",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Zimmer Biomet",
       "model": "ROSA Robotic Surgical Assistant - Hip",
       "serial_number": "ZB-2019-00242",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2024-09-08T09:17:54.278Z",
       "modified": "2026-01-16T08:07:54.278Z",
@@ -6287,7 +6046,6 @@
       "app_sw_version": "v12.5.86",
       "last_scanned": "2026-01-13T11:17:54.278Z",
       "last_pinged": "2026-01-16T08:07:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -6303,8 +6061,8 @@
       "manufacturer": "GE Healthcare",
       "model": "EXCITE HDXT",
       "serial_number": "GH-2019-00243",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-09-07T09:17:54.278Z",
       "modified": "2026-01-16T08:15:54.278Z",
@@ -6313,7 +6071,6 @@
       "app_sw_version": "v14.2.75",
       "last_scanned": "2026-01-14T13:17:54.278Z",
       "last_pinged": "2026-01-16T08:15:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -6329,8 +6086,8 @@
       "manufacturer": "GE Healthcare",
       "model": "EXCITE II",
       "serial_number": "GH-2023-00244",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-12-22T09:17:54.278Z",
       "modified": "2026-01-16T07:52:54.278Z",
@@ -6339,7 +6096,6 @@
       "app_sw_version": "v10.5.28",
       "last_scanned": "2026-01-15T18:17:54.278Z",
       "last_pinged": "2026-01-16T07:52:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6355,8 +6111,8 @@
       "manufacturer": "GE Healthcare",
       "model": "HD",
       "serial_number": "GH-2020-00245",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-05-05T09:17:54.278Z",
       "modified": "2026-01-16T08:48:54.278Z",
@@ -6365,7 +6121,6 @@
       "app_sw_version": "v15.8.27",
       "last_scanned": "2026-01-14T04:17:54.278Z",
       "last_pinged": "2026-01-16T08:48:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6377,12 +6132,12 @@
       "hostname": "med-dev-00246.hospital.local",
       "ip_address": "192.168.169.215",
       "mac_address": "68:54:17:54:bd:4a",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Philips",
       "model": "Ingenia Ambition",
       "serial_number": "P-2019-00246",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-06-17T09:17:54.278Z",
       "modified": "2026-01-16T09:05:54.278Z",
@@ -6391,7 +6146,6 @@
       "app_sw_version": "v11.8.37",
       "last_scanned": "2026-01-15T17:17:54.278Z",
       "last_pinged": "2026-01-16T09:05:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -6407,8 +6161,8 @@
       "manufacturer": "Philips",
       "model": "Ingenia",
       "serial_number": "P-2023-00247",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-05-13T09:17:54.278Z",
       "modified": "2026-01-16T08:16:54.278Z",
@@ -6417,7 +6171,6 @@
       "app_sw_version": "v13.2.25",
       "last_scanned": "2026-01-14T17:17:54.278Z",
       "last_pinged": "2026-01-16T08:16:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6433,8 +6186,8 @@
       "manufacturer": "Philips",
       "model": "Achieva",
       "serial_number": "P-2022-00248",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-02-04T09:17:54.278Z",
       "modified": "2026-01-16T08:48:54.278Z",
@@ -6443,7 +6196,6 @@
       "app_sw_version": "v8.0.53",
       "last_scanned": "2026-01-13T22:17:54.278Z",
       "last_pinged": "2026-01-16T08:48:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6459,8 +6211,8 @@
       "manufacturer": "Philips",
       "model": "Intera",
       "serial_number": "P-2019-00249",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-04-02T09:17:54.278Z",
       "modified": "2026-01-16T08:54:54.278Z",
@@ -6469,7 +6221,6 @@
       "app_sw_version": "v8.7.32",
       "last_scanned": "2026-01-14T14:17:54.278Z",
       "last_pinged": "2026-01-16T08:54:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6485,8 +6236,8 @@
       "manufacturer": "Toshiba/Canon",
       "model": "Vantage Titan",
       "serial_number": "T-2023-00250",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-03-12T09:17:54.278Z",
       "modified": "2026-01-16T09:10:54.278Z",
@@ -6495,7 +6246,6 @@
       "app_sw_version": "v13.0.31",
       "last_scanned": "2026-01-14T02:17:54.278Z",
       "last_pinged": "2026-01-16T09:10:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6511,8 +6261,8 @@
       "manufacturer": "Toshiba/Canon",
       "model": "ExcelArt",
       "serial_number": "T-2019-00251",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-04-16T09:17:54.278Z",
       "modified": "2026-01-16T08:35:54.278Z",
@@ -6521,7 +6271,6 @@
       "app_sw_version": "v5.1.86",
       "last_scanned": "2026-01-14T14:17:54.278Z",
       "last_pinged": "2026-01-16T08:35:54.278Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6537,8 +6286,8 @@
       "manufacturer": "Toshiba/Canon",
       "model": "Vantage Atlas",
       "serial_number": "T-2016-00252",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-06-30T09:17:54.278Z",
       "modified": "2026-01-16T07:19:54.278Z",
@@ -6547,7 +6296,6 @@
       "app_sw_version": "v9.7.9",
       "last_scanned": "2026-01-15T16:17:54.278Z",
       "last_pinged": "2026-01-16T07:19:54.278Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"2762\"]",
       "external_keys": null
     }
   },
@@ -6563,8 +6311,8 @@
       "manufacturer": "Toshiba/Canon",
       "model": "Visart",
       "serial_number": "T-2023-00253",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-03-29T09:17:54.278Z",
       "modified": "2026-01-16T07:51:54.278Z",
@@ -6573,7 +6321,6 @@
       "app_sw_version": "v13.4.49",
       "last_scanned": "2026-01-15T14:17:54.278Z",
       "last_pinged": "2026-01-16T07:51:54.278Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"2762\"]",
       "external_keys": null
     }
   },
@@ -6589,8 +6336,8 @@
       "manufacturer": "Toshiba/Canon",
       "model": "Vantage Orian",
       "serial_number": "T-2021-00254",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2025-07-05T09:17:54.278Z",
       "modified": "2026-01-16T07:44:54.278Z",
@@ -6599,7 +6346,6 @@
       "app_sw_version": "v12.7.62",
       "last_scanned": "2026-01-14T21:17:54.278Z",
       "last_pinged": "2026-01-16T07:44:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6611,12 +6357,12 @@
       "hostname": "med-dev-00255.hospital.local",
       "ip_address": "192.168.132.57",
       "mac_address": "f1:7b:71:47:4e:8d",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Toshiba/Canon",
       "model": "Vantage Elan",
       "serial_number": "T-2016-00255",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-04-10T09:17:54.278Z",
       "modified": "2026-01-16T08:50:54.278Z",
@@ -6625,7 +6371,6 @@
       "app_sw_version": "v13.7.48",
       "last_scanned": "2026-01-15T12:17:54.278Z",
       "last_pinged": "2026-01-16T08:50:54.278Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"2762\"]",
       "external_keys": null
     }
   },
@@ -6641,8 +6386,8 @@
       "manufacturer": "Toshiba/Canon",
       "model": "Opart",
       "serial_number": "T-2019-00256",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "MRI Scanner",
       "created": "2024-02-10T09:17:54.278Z",
       "modified": "2026-01-16T08:29:54.278Z",
@@ -6651,7 +6396,6 @@
       "app_sw_version": "v1.3.8",
       "last_scanned": "2026-01-14T22:17:54.278Z",
       "last_pinged": "2026-01-16T08:29:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -6667,8 +6411,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Optima 660",
       "serial_number": "GH-2020-00257",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-05-21T09:17:54.278Z",
       "modified": "2026-01-16T07:41:54.278Z",
@@ -6677,7 +6421,6 @@
       "app_sw_version": "v6.5.54",
       "last_scanned": "2026-01-14T06:17:54.278Z",
       "last_pinged": "2026-01-16T07:41:54.278Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -6693,8 +6436,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Revolution EVO",
       "serial_number": "GH-2023-00258",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-04-15T09:17:54.278Z",
       "modified": "2026-01-16T07:47:54.278Z",
@@ -6703,7 +6446,6 @@
       "app_sw_version": "v1.3.40",
       "last_scanned": "2026-01-14T11:17:54.278Z",
       "last_pinged": "2026-01-16T07:47:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6715,12 +6457,12 @@
       "hostname": "med-dev-00259.hospital.local",
       "ip_address": "172.17.133.145",
       "mac_address": "ad:c6:45:de:70:fc",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "LightSpeed VCT 64",
       "serial_number": "GH-2018-00259",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-02-03T09:17:54.278Z",
       "modified": "2026-01-16T09:03:54.278Z",
@@ -6729,7 +6471,6 @@
       "app_sw_version": "v8.9.0",
       "last_scanned": "2026-01-15T18:17:54.278Z",
       "last_pinged": "2026-01-16T09:03:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6745,8 +6486,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Optima 540",
       "serial_number": "GH-2015-00260",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-07-06T09:17:54.278Z",
       "modified": "2026-01-16T09:02:54.278Z",
@@ -6755,7 +6496,6 @@
       "app_sw_version": "v9.1.50",
       "last_scanned": "2026-01-13T20:17:54.278Z",
       "last_pinged": "2026-01-16T09:02:54.278Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -6767,12 +6507,12 @@
       "hostname": "med-dev-00261.hospital.local",
       "ip_address": "10.235.7.200",
       "mac_address": "61:8f:0d:f7:68:1c",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "GE Healthcare",
       "model": "BrightSpeed Pro",
       "serial_number": "GH-2016-00261",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-02-18T09:17:54.278Z",
       "modified": "2026-01-16T07:53:54.278Z",
@@ -6781,7 +6521,6 @@
       "app_sw_version": "v12.7.13",
       "last_scanned": "2026-01-15T15:17:54.278Z",
       "last_pinged": "2026-01-16T07:53:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6797,8 +6536,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Optima 520",
       "serial_number": "GH-2015-00262",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-05-19T09:17:54.278Z",
       "modified": "2026-01-16T07:55:54.278Z",
@@ -6807,7 +6546,6 @@
       "app_sw_version": "v15.8.95",
       "last_scanned": "2026-01-13T18:17:54.278Z",
       "last_pinged": "2026-01-16T07:55:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6823,8 +6561,8 @@
       "manufacturer": "GE Healthcare",
       "model": "BrightSpeed Select",
       "serial_number": "GH-2015-00263",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-03-10T09:17:54.278Z",
       "modified": "2026-01-16T07:44:54.278Z",
@@ -6833,7 +6571,6 @@
       "app_sw_version": "v4.9.49",
       "last_scanned": "2026-01-15T10:17:54.278Z",
       "last_pinged": "2026-01-16T07:44:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6849,8 +6586,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Revolution Maxima",
       "serial_number": "GH-2023-00264",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-12-26T09:17:54.278Z",
       "modified": "2026-01-16T08:00:54.278Z",
@@ -6859,7 +6596,6 @@
       "app_sw_version": "v5.3.46",
       "last_scanned": "2026-01-15T15:17:54.278Z",
       "last_pinged": "2026-01-16T08:00:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6875,8 +6611,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "SOMATOM Definition AS",
       "serial_number": "SH-2017-00265",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-08-30T09:17:54.278Z",
       "modified": "2026-01-16T08:32:54.278Z",
@@ -6885,7 +6621,6 @@
       "app_sw_version": "v12.3.70",
       "last_scanned": "2026-01-16T08:17:54.278Z",
       "last_pinged": "2026-01-16T08:32:54.278Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6901,8 +6636,8 @@
       "manufacturer": "Toshiba/Canon",
       "model": "Aquilion ONE",
       "serial_number": "T-2020-00266",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-02-24T09:17:54.278Z",
       "modified": "2026-01-16T07:27:54.278Z",
@@ -6911,7 +6646,6 @@
       "app_sw_version": "v8.3.62",
       "last_scanned": "2026-01-15T14:17:54.278Z",
       "last_pinged": "2026-01-16T07:27:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6927,8 +6661,8 @@
       "manufacturer": "Toshiba/Canon",
       "model": "Aquilion Prime",
       "serial_number": "T-2019-00267",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2025-04-04T09:17:54.278Z",
       "modified": "2026-01-16T08:13:54.278Z",
@@ -6937,7 +6671,6 @@
       "app_sw_version": "v2.1.26",
       "last_scanned": "2026-01-15T19:17:54.278Z",
       "last_pinged": "2026-01-16T08:13:54.278Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6953,8 +6686,8 @@
       "manufacturer": "Toshiba/Canon",
       "model": "Activion 16",
       "serial_number": "T-2023-00268",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-09-14T09:17:54.278Z",
       "modified": "2026-01-16T08:33:54.278Z",
@@ -6963,7 +6696,6 @@
       "app_sw_version": "v9.5.46",
       "last_scanned": "2026-01-15T13:17:54.278Z",
       "last_pinged": "2026-01-16T08:33:54.278Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -6979,8 +6711,8 @@
       "manufacturer": "Philips",
       "model": "Ingenuity",
       "serial_number": "P-2016-00269",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-07-24T09:17:54.278Z",
       "modified": "2026-01-16T08:07:54.278Z",
@@ -6989,7 +6721,6 @@
       "app_sw_version": "v10.1.32",
       "last_scanned": "2026-01-15T07:17:54.278Z",
       "last_pinged": "2026-01-16T08:07:54.278Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -7005,8 +6736,8 @@
       "manufacturer": "Philips",
       "model": "Brilliance 64",
       "serial_number": "P-2019-00270",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "CT Scanner",
       "created": "2024-09-03T09:17:54.278Z",
       "modified": "2026-01-16T08:14:54.278Z",
@@ -7015,7 +6746,6 @@
       "app_sw_version": "v15.0.12",
       "last_scanned": "2026-01-14T04:17:54.278Z",
       "last_pinged": "2026-01-16T08:14:54.278Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -7031,8 +6761,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Optima XR220",
       "serial_number": "GH-2021-00271",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Portable X-ray",
       "created": "2024-03-10T09:17:54.278Z",
       "modified": "2026-01-16T08:32:54.278Z",
@@ -7041,7 +6771,6 @@
       "app_sw_version": "v3.4.70",
       "last_scanned": "2026-01-13T20:17:54.278Z",
       "last_pinged": "2026-01-16T08:32:54.278Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -7057,8 +6786,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Optima XR240",
       "serial_number": "GH-2019-00272",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Portable X-ray",
       "created": "2025-04-17T09:17:54.279Z",
       "modified": "2026-01-16T08:14:54.279Z",
@@ -7067,7 +6796,6 @@
       "app_sw_version": "v9.9.6",
       "last_scanned": "2026-01-13T17:17:54.279Z",
       "last_pinged": "2026-01-16T08:14:54.279Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -7083,8 +6811,8 @@
       "manufacturer": "GE Healthcare",
       "model": "AMX Navigate",
       "serial_number": "GH-2020-00273",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Portable X-ray",
       "created": "2024-08-01T09:17:54.279Z",
       "modified": "2026-01-16T08:18:54.279Z",
@@ -7093,7 +6821,6 @@
       "app_sw_version": "v13.1.18",
       "last_scanned": "2026-01-15T19:17:54.279Z",
       "last_pinged": "2026-01-16T08:18:54.279Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -7109,8 +6836,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Mobilett Mira",
       "serial_number": "SH-2022-00274",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Portable X-ray",
       "created": "2024-07-27T09:17:54.279Z",
       "modified": "2026-01-16T08:59:54.279Z",
@@ -7119,7 +6846,6 @@
       "app_sw_version": "v4.7.52",
       "last_scanned": "2026-01-13T23:17:54.279Z",
       "last_pinged": "2026-01-16T08:59:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -7135,8 +6861,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Mira Max",
       "serial_number": "SH-2015-00275",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Portable X-ray",
       "created": "2025-05-15T09:17:54.279Z",
       "modified": "2026-01-16T08:06:54.279Z",
@@ -7145,7 +6871,6 @@
       "app_sw_version": "v5.5.99",
       "last_scanned": "2026-01-15T08:17:54.279Z",
       "last_pinged": "2026-01-16T08:06:54.279Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -7161,8 +6886,8 @@
       "manufacturer": "Siemens Healthineers",
       "model": "Elara Max",
       "serial_number": "SH-2020-00276",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Portable X-ray",
       "created": "2024-10-14T09:17:54.279Z",
       "modified": "2026-01-16T07:17:54.279Z",
@@ -7171,7 +6896,6 @@
       "app_sw_version": "v4.0.79",
       "last_scanned": "2026-01-14T11:17:54.279Z",
       "last_pinged": "2026-01-16T07:17:54.279Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -7187,8 +6911,8 @@
       "manufacturer": "Carestream",
       "model": "DRX-Revolution",
       "serial_number": "C-2015-00277",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Portable X-ray",
       "created": "2024-12-12T09:17:54.279Z",
       "modified": "2026-01-16T08:03:54.279Z",
@@ -7197,7 +6921,6 @@
       "app_sw_version": "v4.6.93",
       "last_scanned": "2026-01-16T04:17:54.279Z",
       "last_pinged": "2026-01-16T08:03:54.279Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -7213,8 +6936,8 @@
       "manufacturer": "Carestream",
       "model": "DRX-Rise",
       "serial_number": "C-2022-00278",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Portable X-ray",
       "created": "2024-07-17T09:17:54.279Z",
       "modified": "2026-01-16T09:01:54.279Z",
@@ -7223,7 +6946,6 @@
       "app_sw_version": "v12.4.36",
       "last_scanned": "2026-01-14T21:17:54.279Z",
       "last_pinged": "2026-01-16T09:01:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -7239,8 +6961,8 @@
       "manufacturer": "Shimadzu",
       "model": "MobileDaRt",
       "serial_number": "S-2018-00279",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Portable X-ray",
       "created": "2025-03-06T09:17:54.279Z",
       "modified": "2026-01-16T07:55:54.279Z",
@@ -7249,7 +6971,6 @@
       "app_sw_version": "v15.5.33",
       "last_scanned": "2026-01-14T20:17:54.279Z",
       "last_pinged": "2026-01-16T07:55:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -7265,8 +6986,8 @@
       "manufacturer": "Canon",
       "model": "RadPro",
       "serial_number": "C-2015-00280",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Portable X-ray",
       "created": "2024-01-22T09:17:54.279Z",
       "modified": "2026-01-16T07:44:54.279Z",
@@ -7275,7 +6996,6 @@
       "app_sw_version": "v8.6.17",
       "last_scanned": "2026-01-15T06:17:54.279Z",
       "last_pinged": "2026-01-16T07:44:54.279Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -7291,8 +7011,8 @@
       "manufacturer": "Samsung",
       "model": "GM85",
       "serial_number": "S-2021-00281",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Portable X-ray",
       "created": "2024-12-08T09:17:54.279Z",
       "modified": "2026-01-16T08:15:54.279Z",
@@ -7301,7 +7021,6 @@
       "app_sw_version": "v8.1.66",
       "last_scanned": "2026-01-13T23:17:54.279Z",
       "last_pinged": "2026-01-16T08:15:54.279Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -7317,8 +7036,8 @@
       "manufacturer": "Fujifilm",
       "model": "FDR Go",
       "serial_number": "F-2022-00282",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Portable X-ray",
       "created": "2025-05-30T09:17:54.279Z",
       "modified": "2026-01-16T08:46:54.279Z",
@@ -7327,7 +7046,6 @@
       "app_sw_version": "v6.4.49",
       "last_scanned": "2026-01-13T17:17:54.279Z",
       "last_pinged": "2026-01-16T08:46:54.279Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -7343,8 +7061,8 @@
       "manufacturer": "GE Healthcare",
       "model": "OEC 9900",
       "serial_number": "GH-2017-00283",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "C-arm Fluoroscope",
       "created": "2024-08-07T09:17:54.279Z",
       "modified": "2026-01-16T08:39:54.279Z",
@@ -7353,7 +7071,6 @@
       "app_sw_version": "v6.0.60",
       "last_scanned": "2026-01-13T12:17:54.279Z",
       "last_pinged": "2026-01-16T08:39:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -7369,8 +7086,8 @@
       "manufacturer": "GE Healthcare",
       "model": "OEC 9800",
       "serial_number": "GH-2019-00284",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "C-arm Fluoroscope",
       "created": "2024-06-12T09:17:54.279Z",
       "modified": "2026-01-16T07:53:54.279Z",
@@ -7379,7 +7096,6 @@
       "app_sw_version": "v11.0.90",
       "last_scanned": "2026-01-16T02:17:54.279Z",
       "last_pinged": "2026-01-16T07:53:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -7395,8 +7111,8 @@
       "manufacturer": "GE Healthcare",
       "model": "OEC 8800",
       "serial_number": "GH-2015-00285",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "C-arm Fluoroscope",
       "created": "2025-01-13T09:17:54.279Z",
       "modified": "2026-01-16T08:16:54.279Z",
@@ -7405,7 +7121,6 @@
       "app_sw_version": "v12.8.83",
       "last_scanned": "2026-01-14T21:17:54.279Z",
       "last_pinged": "2026-01-16T08:16:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -7421,8 +7136,8 @@
       "manufacturer": "Philips",
       "model": "BV Pulsera",
       "serial_number": "P-2017-00286",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "C-arm Fluoroscope",
       "created": "2025-02-08T09:17:54.279Z",
       "modified": "2026-01-16T07:19:54.279Z",
@@ -7431,7 +7146,6 @@
       "app_sw_version": "v6.8.81",
       "last_scanned": "2026-01-13T21:17:54.279Z",
       "last_pinged": "2026-01-16T07:19:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -7447,8 +7161,8 @@
       "manufacturer": "Mindray",
       "model": "DC-88",
       "serial_number": "M-2023-00287",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-05-02T09:17:54.279Z",
       "modified": "2026-01-16T09:01:54.279Z",
@@ -7457,7 +7171,6 @@
       "app_sw_version": "v6.8.55",
       "last_scanned": "2026-01-16T02:17:54.279Z",
       "last_pinged": "2026-01-16T09:01:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -7469,12 +7182,12 @@
       "hostname": "med-dev-00288.hospital.local",
       "ip_address": "192.168.20.204",
       "mac_address": "93:7f:fc:c0:5c:2d",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Philips",
       "model": "EPIQ Elite",
       "serial_number": "P-2023-00288",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2025-02-19T09:17:54.279Z",
       "modified": "2026-01-16T08:50:54.279Z",
@@ -7483,7 +7196,6 @@
       "app_sw_version": "v4.8.73",
       "last_scanned": "2026-01-14T21:17:54.279Z",
       "last_pinged": "2026-01-16T08:50:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -7499,8 +7211,8 @@
       "manufacturer": "Philips",
       "model": "EPIQ 7G",
       "serial_number": "P-2022-00289",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ultrasound System",
       "created": "2024-04-02T09:17:54.279Z",
       "modified": "2026-01-16T09:06:54.279Z",
@@ -7509,7 +7221,6 @@
       "app_sw_version": "v2.1.81",
       "last_scanned": "2026-01-14T03:17:54.279Z",
       "last_pinged": "2026-01-16T09:06:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -7525,8 +7236,8 @@
       "manufacturer": "Baxter",
       "model": "Flo-Gard 6301",
       "serial_number": "B-2016-00290",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2025-01-04T09:17:54.279Z",
       "modified": "2026-01-16T08:01:54.279Z",
@@ -7535,7 +7246,6 @@
       "app_sw_version": "v9.3.1",
       "last_scanned": "2026-01-15T11:17:54.279Z",
       "last_pinged": "2026-01-16T08:01:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -7547,12 +7257,12 @@
       "hostname": "med-dev-00291.hospital.local",
       "ip_address": "10.47.167.127",
       "mac_address": "1e:91:3f:5f:0e:e0",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Smiths Medical (ICU Medical)",
       "model": "Medfusion 3500",
       "serial_number": "SM-2021-00291",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2025-01-26T09:17:54.279Z",
       "modified": "2026-01-16T07:57:54.279Z",
@@ -7561,7 +7271,6 @@
       "app_sw_version": "v6.3.61",
       "last_scanned": "2026-01-14T22:17:54.279Z",
       "last_pinged": "2026-01-16T07:57:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -7577,8 +7286,8 @@
       "manufacturer": "Smiths Medical (ICU Medical)",
       "model": "CADD 6500",
       "serial_number": "SM-2016-00292",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2024-05-06T09:17:54.279Z",
       "modified": "2026-01-16T08:42:54.279Z",
@@ -7587,7 +7296,6 @@
       "app_sw_version": "v15.1.91",
       "last_scanned": "2026-01-16T01:17:54.279Z",
       "last_pinged": "2026-01-16T08:42:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -7603,8 +7311,8 @@
       "manufacturer": "Smiths Medical (ICU Medical)",
       "model": "CADD Prizm 6101",
       "serial_number": "SM-2019-00293",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2024-02-14T09:17:54.279Z",
       "modified": "2026-01-16T07:40:54.279Z",
@@ -7613,7 +7321,6 @@
       "app_sw_version": "v5.4.0",
       "last_scanned": "2026-01-13T17:17:54.279Z",
       "last_pinged": "2026-01-16T07:40:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -7629,8 +7336,8 @@
       "manufacturer": "BD (CareFusion/Hospira)",
       "model": "Plum A+",
       "serial_number": "B(-2015-00294",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2025-06-01T09:17:54.279Z",
       "modified": "2026-01-16T08:41:54.279Z",
@@ -7639,7 +7346,6 @@
       "app_sw_version": "v7.3.2",
       "last_scanned": "2026-01-14T02:17:54.279Z",
       "last_pinged": "2026-01-16T08:41:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -7655,8 +7361,8 @@
       "manufacturer": "BD (CareFusion/Hospira)",
       "model": "Plum 360",
       "serial_number": "B(-2015-00295",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2025-06-11T09:17:54.279Z",
       "modified": "2026-01-16T07:34:54.279Z",
@@ -7665,7 +7371,6 @@
       "app_sw_version": "v7.3.29",
       "last_scanned": "2026-01-14T14:17:54.279Z",
       "last_pinged": "2026-01-16T07:34:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -7681,8 +7386,8 @@
       "manufacturer": "ICU Medical",
       "model": "IPN",
       "serial_number": "IM-2019-00296",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2024-08-11T09:17:54.279Z",
       "modified": "2026-01-16T09:05:54.279Z",
@@ -7691,7 +7396,6 @@
       "app_sw_version": "v11.4.66",
       "last_scanned": "2026-01-15T22:17:54.279Z",
       "last_pinged": "2026-01-16T09:05:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -7707,8 +7411,8 @@
       "manufacturer": "ICU Medical",
       "model": "Syramed",
       "serial_number": "IM-2018-00297",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Infusion Pump",
       "created": "2024-04-28T09:17:54.279Z",
       "modified": "2026-01-16T09:11:54.279Z",
@@ -7717,7 +7421,6 @@
       "app_sw_version": "v9.3.64",
       "last_scanned": "2026-01-16T02:17:54.279Z",
       "last_pinged": "2026-01-16T09:11:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\", \"9000\"]",
       "external_keys": null
     }
   },
@@ -7733,8 +7436,8 @@
       "manufacturer": "Dr\u00e4ger",
       "model": "Evita",
       "serial_number": "D-2021-00298",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2025-04-15T09:17:54.279Z",
       "modified": "2026-01-16T08:52:54.279Z",
@@ -7743,7 +7446,6 @@
       "app_sw_version": "v15.1.95",
       "last_scanned": "2026-01-15T14:17:54.279Z",
       "last_pinged": "2026-01-16T08:52:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -7759,8 +7461,8 @@
       "manufacturer": "Dr\u00e4ger",
       "model": "Savina",
       "serial_number": "D-2020-00299",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2024-05-27T09:17:54.279Z",
       "modified": "2026-01-16T08:40:54.279Z",
@@ -7769,7 +7471,6 @@
       "app_sw_version": "v14.2.92",
       "last_scanned": "2026-01-13T20:17:54.279Z",
       "last_pinged": "2026-01-16T08:40:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -7785,8 +7486,8 @@
       "manufacturer": "GE Healthcare",
       "model": "Engstr\u00f6m Carestation",
       "serial_number": "GH-2016-00300",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2024-12-25T09:17:54.279Z",
       "modified": "2026-01-16T07:49:54.279Z",
@@ -7795,7 +7496,6 @@
       "app_sw_version": "v10.3.64",
       "last_scanned": "2026-01-16T01:17:54.279Z",
       "last_pinged": "2026-01-16T07:49:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -7811,8 +7511,8 @@
       "manufacturer": "Philips Respironics",
       "model": "V680",
       "serial_number": "PR-2023-00301",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2024-05-01T09:17:54.279Z",
       "modified": "2026-01-16T07:28:54.279Z",
@@ -7821,7 +7521,6 @@
       "app_sw_version": "v4.3.37",
       "last_scanned": "2026-01-16T08:17:54.279Z",
       "last_pinged": "2026-01-16T07:28:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -7833,12 +7532,12 @@
       "hostname": "med-dev-00302.hospital.local",
       "ip_address": "192.168.179.155",
       "mac_address": "3b:99:ac:82:91:5a",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Medtronic",
       "model": "Puritan Bennett 980",
       "serial_number": "M-2016-00302",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Ventilator",
       "created": "2025-05-17T09:17:54.279Z",
       "modified": "2026-01-16T08:55:54.279Z",
@@ -7847,7 +7546,6 @@
       "app_sw_version": "v10.2.95",
       "last_scanned": "2026-01-16T05:17:54.279Z",
       "last_pinged": "2026-01-16T08:55:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8000\", \"8080\", \"9090\"]",
       "external_keys": null
     }
   },
@@ -7863,8 +7561,8 @@
       "manufacturer": "Fresenius Medical Care",
       "model": "5008",
       "serial_number": "FM-2019-00303",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Dialysis Machine",
       "created": "2024-01-19T09:17:54.279Z",
       "modified": "2026-01-16T07:39:54.279Z",
@@ -7873,7 +7571,6 @@
       "app_sw_version": "v2.2.93",
       "last_scanned": "2026-01-14T07:17:54.279Z",
       "last_pinged": "2026-01-16T07:39:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -7885,12 +7582,12 @@
       "hostname": "med-dev-00304.hospital.local",
       "ip_address": "172.29.200.135",
       "mac_address": "0b:c4:85:1e:1e:83",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Fresenius Medical Care",
       "model": "4008",
       "serial_number": "FM-2021-00304",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Dialysis Machine",
       "created": "2024-06-10T09:17:54.279Z",
       "modified": "2026-01-16T09:07:54.279Z",
@@ -7899,7 +7596,6 @@
       "app_sw_version": "v5.8.33",
       "last_scanned": "2026-01-13T23:17:54.279Z",
       "last_pinged": "2026-01-16T09:07:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -7915,8 +7611,8 @@
       "manufacturer": "B. Braun",
       "model": "Dialog",
       "serial_number": "BB-2017-00305",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Dialysis Machine",
       "created": "2025-05-06T09:17:54.279Z",
       "modified": "2026-01-16T07:30:54.279Z",
@@ -7925,7 +7621,6 @@
       "app_sw_version": "v4.4.76",
       "last_scanned": "2026-01-14T23:17:54.279Z",
       "last_pinged": "2026-01-16T07:30:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -7937,12 +7632,12 @@
       "hostname": "med-dev-00306.hospital.local",
       "ip_address": "172.16.101.224",
       "mac_address": "fd:42:50:bf:71:d6",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "NxStage",
       "model": "System One",
       "serial_number": "N-2015-00306",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Dialysis Machine",
       "created": "2025-03-16T09:17:54.279Z",
       "modified": "2026-01-16T09:08:54.279Z",
@@ -7951,7 +7646,6 @@
       "app_sw_version": "v6.8.63",
       "last_scanned": "2026-01-14T14:17:54.279Z",
       "last_pinged": "2026-01-16T09:08:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -7967,8 +7661,8 @@
       "manufacturer": "ZOLL Medical",
       "model": "AED 3",
       "serial_number": "ZM-2019-00307",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-12-17T09:17:54.279Z",
       "modified": "2026-01-16T08:26:54.279Z",
@@ -7977,7 +7671,6 @@
       "app_sw_version": "v8.8.95",
       "last_scanned": "2026-01-16T01:17:54.279Z",
       "last_pinged": "2026-01-16T08:26:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -7993,8 +7686,8 @@
       "manufacturer": "Philips",
       "model": "HeartStart MRx",
       "serial_number": "P-2022-00308",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-08-19T09:17:54.279Z",
       "modified": "2026-01-16T09:01:54.279Z",
@@ -8003,7 +7696,6 @@
       "app_sw_version": "v9.4.83",
       "last_scanned": "2026-01-13T12:17:54.279Z",
       "last_pinged": "2026-01-16T09:01:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -8019,8 +7711,8 @@
       "manufacturer": "Philips",
       "model": "LifePak",
       "serial_number": "P-2018-00309",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-10-15T09:17:54.279Z",
       "modified": "2026-01-16T08:31:54.279Z",
@@ -8029,7 +7721,6 @@
       "app_sw_version": "v9.0.23",
       "last_scanned": "2026-01-15T15:17:54.279Z",
       "last_pinged": "2026-01-16T08:31:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -8045,8 +7736,8 @@
       "manufacturer": "Medtronic (Physio-Control)",
       "model": "Lifepak 15",
       "serial_number": "M(-2020-00310",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-02-18T09:17:54.279Z",
       "modified": "2026-01-16T07:50:54.279Z",
@@ -8055,7 +7746,6 @@
       "app_sw_version": "v14.4.83",
       "last_scanned": "2026-01-14T13:17:54.279Z",
       "last_pinged": "2026-01-16T07:50:54.279Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -8071,8 +7761,8 @@
       "manufacturer": "Nihon Kohden",
       "model": "LifeScope",
       "serial_number": "NK-2016-00311",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2025-07-04T09:17:54.280Z",
       "modified": "2026-01-16T09:00:54.280Z",
@@ -8081,7 +7771,6 @@
       "app_sw_version": "v11.9.1",
       "last_scanned": "2026-01-13T18:17:54.280Z",
       "last_pinged": "2026-01-16T09:00:54.280Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -8097,8 +7786,8 @@
       "manufacturer": "HeartSine",
       "model": "Samaritan",
       "serial_number": "H-2022-00312",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Defibrillator",
       "created": "2024-07-31T09:17:54.280Z",
       "modified": "2026-01-16T07:58:54.280Z",
@@ -8107,7 +7796,6 @@
       "app_sw_version": "v11.4.9",
       "last_scanned": "2026-01-13T10:17:54.280Z",
       "last_pinged": "2026-01-16T07:58:54.280Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -8123,8 +7811,8 @@
       "manufacturer": "Medtronic (Covidien)",
       "model": "Valleylab FT10",
       "serial_number": "M(-2020-00313",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Electrosurgical Unit",
       "created": "2024-10-09T09:17:54.280Z",
       "modified": "2026-01-16T08:20:54.280Z",
@@ -8133,7 +7821,6 @@
       "app_sw_version": "v8.4.30",
       "last_scanned": "2026-01-15T08:17:54.280Z",
       "last_pinged": "2026-01-16T08:20:54.280Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -8149,8 +7836,8 @@
       "manufacturer": "Medtronic (Covidien)",
       "model": "Valleylab Force FXc",
       "serial_number": "M(-2016-00314",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Electrosurgical Unit",
       "created": "2024-06-30T09:17:54.280Z",
       "modified": "2026-01-16T08:10:54.280Z",
@@ -8159,7 +7846,6 @@
       "app_sw_version": "v4.2.87",
       "last_scanned": "2026-01-14T23:17:54.280Z",
       "last_pinged": "2026-01-16T08:10:54.280Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2761\", \"2762\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -8175,8 +7861,8 @@
       "manufacturer": "ConMed",
       "model": "System 5000",
       "serial_number": "C-2016-00315",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Electrosurgical Unit",
       "created": "2024-05-08T09:17:54.280Z",
       "modified": "2026-01-16T07:48:54.280Z",
@@ -8185,7 +7871,6 @@
       "app_sw_version": "v8.0.84",
       "last_scanned": "2026-01-16T04:17:54.280Z",
       "last_pinged": "2026-01-16T07:48:54.280Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -8201,8 +7886,8 @@
       "manufacturer": "ConMed",
       "model": "System 2450",
       "serial_number": "C-2019-00316",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Electrosurgical Unit",
       "created": "2024-12-26T09:17:54.280Z",
       "modified": "2026-01-16T07:57:54.280Z",
@@ -8211,7 +7896,6 @@
       "app_sw_version": "v10.8.17",
       "last_scanned": "2026-01-14T23:17:54.280Z",
       "last_pinged": "2026-01-16T07:57:54.280Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2762\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -8227,8 +7911,8 @@
       "manufacturer": "Ethicon (Johnson & Johnson)",
       "model": "Gen11 Harmonic Scalpel",
       "serial_number": "E(-2021-00317",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Electrosurgical Unit",
       "created": "2025-04-25T09:17:54.280Z",
       "modified": "2026-01-16T07:55:54.280Z",
@@ -8237,7 +7921,6 @@
       "app_sw_version": "v3.6.98",
       "last_scanned": "2026-01-15T00:17:54.280Z",
       "last_pinged": "2026-01-16T07:55:54.280Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"2762\", \"3389\", \"8080\"]",
       "external_keys": null
     }
   },
@@ -8253,8 +7936,8 @@
       "manufacturer": "Bovie",
       "model": "A3350",
       "serial_number": "B-2019-00318",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Electrosurgical Unit",
       "created": "2024-01-29T09:17:54.280Z",
       "modified": "2026-01-16T07:48:54.280Z",
@@ -8263,7 +7946,6 @@
       "app_sw_version": "v11.9.89",
       "last_scanned": "2026-01-14T11:17:54.280Z",
       "last_pinged": "2026-01-16T07:48:54.280Z",
-      "open_ports_tcp": "[\"80\", \"104\", \"443\", \"2761\", \"3389\"]",
       "external_keys": null
     }
   },
@@ -8279,8 +7961,8 @@
       "manufacturer": "Intuitive Surgical",
       "model": "da Vinci X",
       "serial_number": "IS-2018-00319",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2025-05-09T09:17:54.280Z",
       "modified": "2026-01-16T08:24:54.280Z",
@@ -8289,7 +7971,6 @@
       "app_sw_version": "v1.1.32",
       "last_scanned": "2026-01-15T05:17:54.280Z",
       "last_pinged": "2026-01-16T08:24:54.280Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -8305,8 +7986,8 @@
       "manufacturer": "Intuitive Surgical",
       "model": "da Vinci SP",
       "serial_number": "IS-2019-00320",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2025-03-20T09:17:54.280Z",
       "modified": "2026-01-16T08:03:54.280Z",
@@ -8315,7 +7996,6 @@
       "app_sw_version": "v15.3.33",
       "last_scanned": "2026-01-14T15:17:54.280Z",
       "last_pinged": "2026-01-16T08:03:54.280Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -8331,8 +8011,8 @@
       "manufacturer": "Intuitive Surgical",
       "model": "da Vinci 5",
       "serial_number": "IS-2015-00321",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2024-08-15T09:17:54.280Z",
       "modified": "2026-01-16T08:11:54.280Z",
@@ -8341,7 +8021,6 @@
       "app_sw_version": "v1.9.64",
       "last_scanned": "2026-01-15T15:17:54.280Z",
       "last_pinged": "2026-01-16T08:11:54.280Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -8357,8 +8036,8 @@
       "manufacturer": "Medtronic",
       "model": "StealthStation S8",
       "serial_number": "M-2016-00322",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2025-02-15T09:17:54.280Z",
       "modified": "2026-01-16T08:16:54.280Z",
@@ -8367,7 +8046,6 @@
       "app_sw_version": "v14.8.70",
       "last_scanned": "2026-01-15T17:17:54.280Z",
       "last_pinged": "2026-01-16T08:16:54.280Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -8379,12 +8057,12 @@
       "hostname": "med-dev-00323.hospital.local",
       "ip_address": "192.168.211.28",
       "mac_address": "11:7c:02:9a:c8:c8",
-      "nic_vendor": null,
+      "nic_vendor": "",
       "manufacturer": "Medtronic",
       "model": "Mazor X",
       "serial_number": "M-2022-00323",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2024-05-04T09:17:54.280Z",
       "modified": "2026-01-16T07:41:54.280Z",
@@ -8393,7 +8071,6 @@
       "app_sw_version": "v14.7.29",
       "last_scanned": "2026-01-15T19:17:54.280Z",
       "last_pinged": "2026-01-16T07:41:54.280Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -8409,8 +8086,8 @@
       "manufacturer": "Brainlab",
       "model": "Curve",
       "serial_number": "B-2019-00324",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2025-06-05T09:17:54.280Z",
       "modified": "2026-01-16T09:01:54.280Z",
@@ -8419,7 +8096,6 @@
       "app_sw_version": "v5.8.19",
       "last_scanned": "2026-01-14T04:17:54.280Z",
       "last_pinged": "2026-01-16T09:01:54.280Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -8435,8 +8111,8 @@
       "manufacturer": "Brainlab",
       "model": "Kick",
       "serial_number": "B-2020-00325",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2024-01-17T09:17:54.280Z",
       "modified": "2026-01-16T09:06:54.280Z",
@@ -8445,7 +8121,6 @@
       "app_sw_version": "v13.9.80",
       "last_scanned": "2026-01-14T04:17:54.280Z",
       "last_pinged": "2026-01-16T09:06:54.280Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   },
@@ -8461,8 +8136,8 @@
       "manufacturer": "Stryker",
       "model": "Nav3",
       "serial_number": "S-2017-00326",
-      "udi": null,
-      "tag_number": null,
+      "udi": "",
+      "tag_number": "",
       "category": "Surgical Robot",
       "created": "2024-11-27T09:17:54.280Z",
       "modified": "2026-01-16T08:46:54.280Z",
@@ -8471,7 +8146,6 @@
       "app_sw_version": "v12.1.50",
       "last_scanned": "2026-01-15T17:17:54.280Z",
       "last_pinged": "2026-01-16T08:46:54.280Z",
-      "open_ports_tcp": "[\"80\", \"443\", \"8080\", \"8443\"]",
       "external_keys": null
     }
   }


### PR DESCRIPTION
<img width="1115" height="96" alt="Screenshot 2026-07-01 at 12 29 56" src="https://github.com/user-attachments/assets/afb92c07-6f51-4d88-b9f9-6bd25f8fe573" />
<img width="409" height="138" alt="Screenshot 2026-07-01 at 12 30 27" src="https://github.com/user-attachments/assets/bad41079-e12c-4dd1-8ec7-b42e582fe6c7" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `create_assets` with Django fixture-style assets and updates `data/assets.json` so `manage.py create_assets` loads sample assets without errors.

- **Bug Fixes**
  - Parser now expects a list of objects with `pk` and `fields` (Django fixture format).
  - Maps `pk` to `id` and reads fields via a safe `_get_field` helper.
  - Switches to `json.load` and `pathlib.Path` for simpler, safer file IO.

- **Migration**
  - If you have custom asset JSON, convert it to fixture format: `[{"pk": 1, "fields": { ... }}]`.

<sup>Written for commit d76193a12f6f2d8df4765ae87ce5d2d0ae4df0eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/virtalabs/blueflow/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

