### PR TITLE
Bump grace period

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -16,9 +16,9 @@ primary_region = 'iad'
   processes = ['app']
 
   [[http_service.checks]]
+    grace_period = '20s'
     interval = '30s'
     timeout = '5s'
-    grace_period = '10s'
     method = 'GET'
     path = '/api/'
     [http_service.checks.headers]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase the Fly HTTP health check grace period from 10s to 20s in `fly.toml` to give the app more time to start and reduce false unhealthy reports during deploys.

<sup>Written for commit 68d0fbfd5bcdb52513b888646bceb23dd086d7c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/virtalabs/blueflow/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

