### PR TITLE
Feature/update bulk create assets

### DIFF
--- a/bandit.json
+++ b/bandit.json
@@ -7,7 +7,7 @@
   "SEVERITY.LOW": 5,
   "SEVERITY.MEDIUM": 2,
   "SEVERITY.UNDEFINED": 0,
-  "loc": 6527,
+  "loc": 5506,
   "nosec": 0,
-  "skipped_tests": 0
+  "skipped_tests": 1
 }

--- a/blueflow/management/commands/create_assets.py
+++ b/blueflow/management/commands/create_assets.py
@@ -46,14 +46,14 @@ def make_assets(data: list[AssetJson]) -> abc.Generator[dict[str, str], None, No
 def insert_assets(raw_assets: abc.Iterable[dict[str, str]]) -> None:
     """Bulk create assets.
 
-    Asset is a child of the concreate model System. Thus django's
+    Asset is a child of the concrete model System. Thus django's
     bulk_create method wont work on Asset directly. The workaround below
-    is to first bulk_create the parent using the ID's from the json file.
+    is to first bulk_create the parent using the IDs from the json file.
     Then drop into a manual bulk create SQL using `executemany` while
     providing the link to the parent column containing the ID.
 
     Alternatively it is also possible to forgo the manual insertion of IDs
-    and lets PostgreSQL handle the IDs itself. These can be obtained from the
+    and let PostgreSQL handle the IDs itself. These can be obtained from the
     System.objects.bulk_create() response.
     """
     System = apps.get_model("blueflow", "System")

--- a/blueflow/management/commands/create_assets.py
+++ b/blueflow/management/commands/create_assets.py
@@ -43,7 +43,7 @@ def make_assets(data: list[AssetJson]) -> abc.Generator[dict[str, str], None, No
         }
 
 
-def insert_assets(assets: abc.Iterable[dict[str, str]]) -> None:
+def insert_assets(raw_assets: abc.Iterable[dict[str, str]]) -> None:
     """Bulk create assets.
 
     Asset is a child of the concreate model System. Thus django's
@@ -56,9 +56,10 @@ def insert_assets(assets: abc.Iterable[dict[str, str]]) -> None:
     and lets PostgreSQL handle the IDs itself. These can be obtained from the
     System.objects.bulk_create() response.
     """
-    System = apps.get_model("blueflow", "Asset")  # noqa: N806
+    System = apps.get_model("blueflow", "System")
     Asset = apps.get_model("blueflow", "Asset")
     with transaction.atomic():
+        assets = list(raw_assets)
         _ = System.objects.bulk_create([System(id=a["id"]) for a in assets])
         asset_table = Asset._meta.db_table  # noqa: SLF001
         system_link = Asset._meta.parents[System].column  # noqa: SLF001
@@ -66,12 +67,12 @@ def insert_assets(assets: abc.Iterable[dict[str, str]]) -> None:
             cursor.executemany(
                 f"INSERT INTO {asset_table} "  # nosec B608 # noqa: S608
                 f"({system_link}, name, hostname, "
-                f"ip_address, mac_address, oui_manufacturer "
-                f"manufacturer, model, serial_number "
-                f"udi, tag_number, category "
-                f"owner, os, app_sw_version "
+                f"ip_address, mac_address, oui_manufacturer, "
+                f"manufacturer, model, serial_number, "
+                f"udi, tag_number, category, "
+                f"owner, os, app_sw_version, "
                 f"last_scanned, last_pinged, external_keys) "
-                f"VALUES (%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s)",
+                f"VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",  # noqa: E501
                 [
                     (
                         a["id"],
@@ -118,6 +119,4 @@ class Command(base.BaseCommand):
             assets = make_assets(data)
             insert_assets(assets)
         Asset = apps.get_model("blueflow", "Asset")
-        self.stdout.write(
-            self.style.SUCCESS(f"Loaded {len(Asset.objects.all())} assets")
-        )
+        self.stdout.write(self.style.SUCCESS(f"Loaded {Asset.objects.count()} assets"))

--- a/blueflow/management/commands/create_assets.py
+++ b/blueflow/management/commands/create_assets.py
@@ -7,13 +7,19 @@ from collections import abc
 
 from django.apps import apps
 from django.core.management import base
+from django.db import connection, transaction
 
 
-def _get_field(asset: dict, key: str, parent: str = "fields") -> typing.Any:
-    return asset.get(parent, {})[key]
+class AssetJson(typing.TypedDict):
+    pk: str
+    fields: dict[str, str]
 
 
-def make_assets(data: list[dict]) -> abc.Generator[dict, None, None]:
+def _get_field(asset: AssetJson, key: str, parent: str = "fields") -> str:
+    return asset[parent][key]
+
+
+def make_assets(data: list[AssetJson]) -> abc.Generator[dict[str, str], None, None]:
     for asset in data:
         yield {
             "id": asset["pk"],
@@ -37,6 +43,61 @@ def make_assets(data: list[dict]) -> abc.Generator[dict, None, None]:
         }
 
 
+def insert_assets(assets: abc.Iterable[dict[str, str]]) -> None:
+    """Bulk create assets.
+
+    Asset is a child of the concreate model System. Thus django's
+    bulk_create method wont work on Asset directly. The workaround below
+    is to first bulk_create the parent using the ID's from the json file.
+    Then drop into a manual bulk create SQL using `executemany` while
+    providing the link to the parent column containing the ID.
+
+    Alternatively it is also possible to forgo the manual insertion of IDs
+    and lets PostgreSQL handle the IDs itself. These can be obtained from the
+    System.objects.bulk_create() response.
+    """
+    System = apps.get_model("blueflow", "Asset")  # noqa: N806
+    Asset = apps.get_model("blueflow", "Asset")
+    with transaction.atomic():
+        _ = System.objects.bulk_create([System(id=a["id"]) for a in assets])
+        asset_table = Asset._meta.db_table  # noqa: SLF001
+        system_link = Asset._meta.parents[System].column  # noqa: SLF001
+        with connection.cursor() as cursor:
+            cursor.executemany(
+                f"INSERT INTO {asset_table} "  # nosec B608 # noqa: S608
+                f"({system_link}, name, hostname, "
+                f"ip_address, mac_address, oui_manufacturer "
+                f"manufacturer, model, serial_number "
+                f"udi, tag_number, category "
+                f"owner, os, app_sw_version "
+                f"last_scanned, last_pinged, external_keys) "
+                f"VALUES (%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s)",
+                [
+                    (
+                        a["id"],
+                        a["name"],
+                        a["hostname"],
+                        a["ip_address"],
+                        a["mac_address"],
+                        a["oui_manufacturer"],
+                        a["manufacturer"],
+                        a["model"],
+                        a["serial_number"],
+                        a["udi"],
+                        a["tag_number"],
+                        a["category"],
+                        a["owner"],
+                        a["os"],
+                        a["app_sw_version"],
+                        a["last_scanned"],
+                        a["last_pinged"],
+                        a["external_keys"],
+                    )
+                    for a in assets
+                ],
+            )
+
+
 class Command(base.BaseCommand):
     """Django manage.py sub command loads assets from a json file."""
 
@@ -48,12 +109,15 @@ class Command(base.BaseCommand):
         )
 
     def handle(self, *_, **options) -> None:
-        Asset = apps.get_model("blueflow", "Asset")
         file_path = options.get("filepath")
+        if not file_path:
+            msg = "Filepath can't be falsey"
+            raise TypeError(msg)
         with pathlib.Path(file_path).open(encoding="utf-8") as file:
             data = json.load(file)
             assets = make_assets(data)
-            Asset.objects.bulk_create([Asset(**asset) for asset in assets])
+            insert_assets(assets)
+        Asset = apps.get_model("blueflow", "Asset")
         self.stdout.write(
             self.style.SUCCESS(f"Loaded {len(Asset.objects.all())} assets")
         )

--- a/blueflow/management/commands/create_assets.py
+++ b/blueflow/management/commands/create_assets.py
@@ -113,7 +113,7 @@ class Command(base.BaseCommand):
         file_path = options.get("filepath")
         if not file_path:
             msg = "Filepath can't be falsey"
-            raise TypeError(msg)
+            raise base.CommandError(msg)
         with pathlib.Path(file_path).open(encoding="utf-8") as file:
             data = json.load(file)
             assets = make_assets(data)


### PR DESCRIPTION
<img width="669" height="128" alt="Screenshot 2026-07-16 at 09 58 14" src="https://github.com/user-attachments/assets/ad9ae6f1-93f9-487e-833b-548dac201774" />
<img width="1512" height="273" alt="Screenshot 2026-07-16 at 09 58 33" src="https://github.com/user-attachments/assets/ccd9af83-066e-47ab-95d9-34254fffc73f" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bulk asset creation for `Asset` now that it inherits from concrete `System`. We create `System` parents first, then bulk-insert `Asset` rows with `executemany` inside a transaction.

- **Bug Fixes**
  - Manual SQL import uses `executemany` and links to the `System` parent column.
  - All writes wrapped in `transaction.atomic()`.
  - Raise `CommandError` when `--filepath` is missing; success output uses `count()`.

- **Refactors**
  - Added `AssetJson` `TypedDict` and stricter types for `_get_field` and `make_assets`.
  - Extracted `insert_assets()` and simplified command flow.
  - Updated `bandit.json` (reduced LOC; 1 skipped test).

<sup>Written for commit 56a5b1803ac82eab522d6580294d45915e0e306e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/virtalabs/blueflow/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

